### PR TITLE
Add basic process sandbox for blend

### DIFF
--- a/RETRO.md
+++ b/RETRO.md
@@ -11,6 +11,25 @@ Future work may let `blend` understand system package availability, report
 missing packages for active orders, or grow into a broader package-management
 layer. That is intentionally out of scope for the current bootstrap path.
 
+## Sandbox Is Currently Process-Scoped
+
+The first `blend` sandbox layer is intentionally small: install early, then deny
+new process execution and new socket-based communication. On Linux this means a
+seccomp denylist for `execve`/`execveat` and socket syscalls, including Unix
+domain socket creation through `socket`/`socketpair`. On macOS this maps to a
+Seatbelt profile that denies process execution and network access.
+
+That is useful hardening, but it is not yet a full least-privilege model. It
+does not describe which files an order may read or write, and it does not stop
+ordinary reads/writes on file descriptors inherited before the sandbox is
+installed. Future sandbox iterations should treat execution as staged:
+
+- disable permissions that are never needed as early as possible;
+- evaluate orders before filesystem tightening so `blend` can calculate the
+  dynamic set of source, overlay, target, and state paths it may touch;
+- apply an explicit filesystem allowlist with Landlock on Linux and Seatbelt on
+  macOS, leaving only the evaluated order footprint writable/readable as needed.
+
 ## Nickel Source Editing Without a Native CST
 
 Nickel gives us an embeddable evaluator and a parser with useful AST byte spans,

--- a/blend/src/cli.rs
+++ b/blend/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+use crate::sandbox::SandboxMode;
+
 #[derive(Parser)]
 #[command(
     name = "blend",
@@ -26,6 +28,10 @@ pub struct Cli {
     /// Override blend directory (the parent directory that contains orders/)
     #[arg(long = "blend-dir", global = true)]
     pub blend_dir: Option<PathBuf>,
+
+    /// Process sandbox policy
+    #[arg(long, value_enum, global = true)]
+    pub sandbox: Option<SandboxMode>,
 }
 
 #[derive(Subcommand)]

--- a/blend/src/commands/init.rs
+++ b/blend/src/commands/init.rs
@@ -142,6 +142,7 @@ fn starter_ncl(ctx: &Context) -> anyhow::Result<String> {
         name = "config.toml",
         from_config = {{
           blend_dir = {blend_dir},
+          sandbox = "prefer",
         }},
       }},
     ],

--- a/blend/src/context.rs
+++ b/blend/src/context.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::cli::{Cli, Commands};
 use crate::metadata::Metadata;
 use crate::output::log;
+use crate::sandbox::SandboxMode;
 use crate::state::StateStore;
 
 /// Runtime context for blend operations
@@ -22,9 +23,7 @@ pub struct Context {
 
 impl Context {
     pub fn new(cli: &Cli) -> Result<Self> {
-        let home_dir = cli.home.clone().unwrap_or_else(|| {
-            PathBuf::from(std::env::var("HOME").expect("Could not determine home directory"))
-        });
+        let home_dir = home_dir_from_cli(cli);
 
         let blend_dir_choice = resolve_blend_dir(cli, &home_dir)?;
         let blend_dir = blend_dir_choice.path;
@@ -80,6 +79,9 @@ impl Context {
 #[derive(Deserialize, Serialize)]
 struct BlendConfig {
     blend_dir: PathBuf,
+
+    #[serde(default)]
+    sandbox: SandboxMode,
 }
 
 struct BlendDirChoice {
@@ -158,7 +160,28 @@ fn config_path(home_dir: &Path) -> PathBuf {
     home_dir.join(".config/blend/config.toml")
 }
 
+pub fn home_dir_from_cli(cli: &Cli) -> PathBuf {
+    cli.home.clone().unwrap_or_else(|| {
+        PathBuf::from(std::env::var("HOME").expect("Could not determine home directory"))
+    })
+}
+
+pub fn sandbox_mode_from_cli_and_config(cli: &Cli) -> Result<SandboxMode> {
+    if let Some(sandbox) = cli.sandbox {
+        return Ok(sandbox);
+    }
+
+    let home_dir = home_dir_from_cli(cli);
+    Ok(read_blend_config(&home_dir)?
+        .map(|config| config.sandbox)
+        .unwrap_or_default())
+}
+
 fn find_blend_dir_from_config(home_dir: &Path) -> Result<Option<PathBuf>> {
+    Ok(read_blend_config(home_dir)?.map(|config| config.blend_dir))
+}
+
+fn read_blend_config(home_dir: &Path) -> Result<Option<BlendConfig>> {
     let path = config_path(home_dir);
     if !path.exists() {
         return Ok(None);
@@ -169,7 +192,7 @@ fn find_blend_dir_from_config(home_dir: &Path) -> Result<Option<PathBuf>> {
     let config: BlendConfig =
         toml::from_str(&raw).with_context(|| format!("Failed to parse {}", path.display()))?;
 
-    Ok(Some(config.blend_dir))
+    Ok(Some(config))
 }
 
 fn find_blend_dir_from_current_dir() -> Option<PathBuf> {
@@ -190,8 +213,12 @@ fn write_blend_dir_config(home_dir: &Path, blend_dir: &Path) -> Result<()> {
             .with_context(|| format!("Failed to create {}", parent.display()))?;
     }
 
+    let sandbox = read_blend_config(home_dir)?
+        .map(|config| config.sandbox)
+        .unwrap_or_default();
     let config = BlendConfig {
         blend_dir: blend_dir.to_path_buf(),
+        sandbox,
     };
     let raw = toml::to_string_pretty(&config)?;
     std::fs::write(&path, raw).with_context(|| format!("Failed to write {}", path.display()))?;
@@ -250,5 +277,95 @@ mod tests {
                 None => std::env::remove_var("XDG_STATE_HOME"),
             }
         }
+    }
+
+    #[test]
+    fn sandbox_mode_defaults_to_prefer_when_config_is_absent() {
+        let tmp = TempDir::new().unwrap();
+        let cli = Cli::parse_from([
+            "blend",
+            "--home",
+            tmp.path().to_str().unwrap(),
+            "--blend-dir",
+            tmp.path().to_str().unwrap(),
+        ]);
+
+        assert_eq!(
+            sandbox_mode_from_cli_and_config(&cli).unwrap(),
+            SandboxMode::Prefer
+        );
+    }
+
+    #[test]
+    fn sandbox_mode_reads_config() {
+        let home = TempDir::new().unwrap();
+        let blend_dir = TempDir::new().unwrap();
+        let config_dir = home.path().join(".config/blend");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "blend_dir = \"{}\"\nsandbox = \"never\"\n",
+                blend_dir.path().display()
+            ),
+        )
+        .unwrap();
+        let cli = Cli::parse_from(["blend", "--home", home.path().to_str().unwrap()]);
+
+        assert_eq!(
+            sandbox_mode_from_cli_and_config(&cli).unwrap(),
+            SandboxMode::Never
+        );
+    }
+
+    #[test]
+    fn sandbox_cli_flags_override_config() {
+        let home = TempDir::new().unwrap();
+        let blend_dir = TempDir::new().unwrap();
+        let config_dir = home.path().join(".config/blend");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "blend_dir = \"{}\"\nsandbox = \"never\"\n",
+                blend_dir.path().display()
+            ),
+        )
+        .unwrap();
+        let cli = Cli::parse_from([
+            "blend",
+            "--home",
+            home.path().to_str().unwrap(),
+            "--sandbox",
+            "force",
+        ]);
+
+        assert_eq!(
+            sandbox_mode_from_cli_and_config(&cli).unwrap(),
+            SandboxMode::Force
+        );
+    }
+
+    #[test]
+    fn write_blend_dir_config_preserves_sandbox_mode() {
+        let home = TempDir::new().unwrap();
+        let old_blend_dir = TempDir::new().unwrap();
+        let new_blend_dir = TempDir::new().unwrap();
+        let config_dir = home.path().join(".config/blend");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                "blend_dir = \"{}\"\nsandbox = \"never\"\n",
+                old_blend_dir.path().display()
+            ),
+        )
+        .unwrap();
+
+        write_blend_dir_config(home.path(), new_blend_dir.path()).unwrap();
+
+        let raw = std::fs::read_to_string(config_dir.join("config.toml")).unwrap();
+        assert!(raw.contains(&new_blend_dir.path().display().to_string()));
+        assert!(raw.contains("sandbox = \"never\""));
     }
 }

--- a/blend/src/main.rs
+++ b/blend/src/main.rs
@@ -8,6 +8,7 @@ mod immutable;
 mod metadata;
 mod nickel;
 mod output;
+mod sandbox;
 mod state;
 mod sync;
 
@@ -15,12 +16,53 @@ use clap::Parser;
 
 use cli::{Cli, Commands};
 use commands::{cmd_init, cmd_status, cmd_sync, cmd_table, cmd_view};
-use context::Context;
+use context::{Context, sandbox_mode_from_cli_and_config};
 use output::log;
+use sandbox::SandboxMode;
 use sync::{SyncMode, TerminalPrompter};
 
 fn main() {
     let cli = Cli::parse();
+    let sandbox_mode = match sandbox_mode_from_cli_and_config(&cli) {
+        Ok(mode) => mode,
+        Err(e) => {
+            log::error(&format!("Error: {e}"));
+            std::process::exit(1);
+        }
+    };
+    let sandbox_installed = match sandbox_mode {
+        SandboxMode::Force | SandboxMode::Prefer => match sandbox::install() {
+            Ok(()) if cli.verbose => {
+                log::info("Enabled process sandbox");
+                true
+            }
+            Ok(()) => true,
+            Err(e) if sandbox_mode == SandboxMode::Force => {
+                log::error(&format!("Error: failed to enable process sandbox: {e}"));
+                std::process::exit(1);
+            }
+            Err(e) => {
+                log::warn(&format!("failed to enable process sandbox: {e}"));
+                false
+            }
+        },
+        SandboxMode::Never => {
+            if cli.verbose {
+                log::info("Process sandbox disabled");
+            }
+            false
+        }
+    };
+
+    #[cfg(not(debug_assertions))]
+    let _ = sandbox_installed;
+
+    #[cfg(debug_assertions)]
+    if sandbox_installed && let Err(e) = sandbox::run_probe_from_env() {
+        log::error(&format!("Error: sandbox probe failed: {e}"));
+        std::process::exit(1);
+    }
+
     let ctx = match Context::new(&cli) {
         Ok(ctx) => ctx,
         Err(e) => {

--- a/blend/src/sandbox.rs
+++ b/blend/src/sandbox.rs
@@ -1,0 +1,261 @@
+use anyhow::Result;
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxMode {
+    Force,
+    #[default]
+    Prefer,
+    Never,
+}
+
+/// Install blend's process sandbox.
+///
+/// The first hardening layer deliberately stays narrow: deny later process
+/// execution and socket-based networking, while leaving filesystem access to
+/// blend's existing ownership and path checks.
+pub fn install() -> Result<()> {
+    platform::install()
+}
+
+#[cfg(debug_assertions)]
+pub fn run_probe_from_env() -> Result<()> {
+    let Ok(probe) = std::env::var("BLEND_SANDBOX_PROBE") else {
+        return Ok(());
+    };
+
+    match probe.as_str() {
+        "exec" => probe::exec(),
+        other => anyhow::bail!("unknown BLEND_SANDBOX_PROBE={other:?}; expected \"exec\""),
+    }
+}
+
+#[cfg(debug_assertions)]
+mod probe {
+    use std::process::Command;
+
+    use anyhow::{Context, Result, bail};
+
+    pub fn exec() -> Result<()> {
+        match Command::new("/bin/sh").arg("-c").arg("true").status() {
+            Ok(status) => bail!("exec probe unexpectedly succeeded with status {status}"),
+            Err(e) if is_permission_denied(&e) => Ok(()),
+            Err(e) => Err(e).context("exec probe failed for an unexpected reason"),
+        }
+    }
+
+    fn is_permission_denied(error: &std::io::Error) -> bool {
+        error.kind() == std::io::ErrorKind::PermissionDenied
+            || error.raw_os_error() == Some(libc::EPERM)
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use anyhow::{Context, Result};
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    pub fn install() -> Result<()> {
+        install_seccomp()
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    pub fn install() -> Result<()> {
+        anyhow::bail!(
+            "seccomp sandbox is not wired for Linux architecture {}",
+            std::env::consts::ARCH
+        );
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn install_seccomp() -> Result<()> {
+        let mut filter = vec![
+            stmt(
+                libc::BPF_LD | libc::BPF_W | libc::BPF_ABS,
+                SECCOMP_DATA_ARCH_OFFSET,
+            ),
+            jump(
+                libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K,
+                AUDIT_ARCH,
+                1,
+                0,
+            ),
+            stmt(libc::BPF_RET | libc::BPF_K, libc::SECCOMP_RET_KILL_PROCESS),
+            stmt(
+                libc::BPF_LD | libc::BPF_W | libc::BPF_ABS,
+                SECCOMP_DATA_NR_OFFSET,
+            ),
+        ];
+
+        for &syscall in denied_syscalls() {
+            filter.push(jump(
+                libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K,
+                syscall as u32,
+                0,
+                1,
+            ));
+            filter.push(stmt(
+                libc::BPF_RET | libc::BPF_K,
+                libc::SECCOMP_RET_ERRNO | libc::EPERM as u32,
+            ));
+        }
+
+        filter.push(stmt(libc::BPF_RET | libc::BPF_K, libc::SECCOMP_RET_ALLOW));
+
+        let mut prog = libc::sock_fprog {
+            len: filter
+                .len()
+                .try_into()
+                .context("seccomp filter is too large")?,
+            filter: filter.as_mut_ptr(),
+        };
+
+        let no_new_privs = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+        if no_new_privs == -1 {
+            return Err(std::io::Error::last_os_error())
+                .context("prctl(PR_SET_NO_NEW_PRIVS) failed");
+        }
+
+        let seccomp = unsafe {
+            libc::prctl(
+                libc::PR_SET_SECCOMP,
+                libc::SECCOMP_MODE_FILTER,
+                &mut prog as *mut libc::sock_fprog,
+            )
+        };
+        if seccomp == -1 {
+            return Err(std::io::Error::last_os_error()).context("prctl(PR_SET_SECCOMP) failed");
+        }
+
+        Ok(())
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn denied_syscalls() -> &'static [libc::c_long] {
+        &[
+            libc::SYS_execve,
+            libc::SYS_execveat,
+            libc::SYS_socket,
+            libc::SYS_socketpair,
+            libc::SYS_connect,
+            libc::SYS_bind,
+            libc::SYS_listen,
+            libc::SYS_accept,
+            libc::SYS_accept4,
+            libc::SYS_sendto,
+            libc::SYS_recvfrom,
+            libc::SYS_sendmsg,
+            libc::SYS_recvmsg,
+            libc::SYS_sendmmsg,
+            libc::SYS_recvmmsg,
+            libc::SYS_setsockopt,
+            libc::SYS_getsockopt,
+            libc::SYS_getsockname,
+            libc::SYS_getpeername,
+            libc::SYS_shutdown,
+        ]
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn stmt(code: u32, k: u32) -> libc::sock_filter {
+        libc::sock_filter {
+            code: code as u16,
+            jt: 0,
+            jf: 0,
+            k,
+        }
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn jump(code: u32, k: u32, jt: u8, jf: u8) -> libc::sock_filter {
+        libc::sock_filter {
+            code: code as u16,
+            jt,
+            jf,
+            k,
+        }
+    }
+
+    // Linux UAPI: `struct seccomp_data` in include/uapi/linux/seccomp.h.
+    // Classic BPF loads fields by byte offset from this struct.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    const SECCOMP_DATA_NR_OFFSET: u32 = 0;
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    const SECCOMP_DATA_ARCH_OFFSET: u32 = 4;
+
+    // Linux UAPI: `AUDIT_ARCH_*` in include/uapi/linux/audit.h.
+    // Values are ELF EM_* machine ids OR'd with audit ABI flags.
+    // libc does not expose these audit constants consistently, so keep the
+    // small set blend supports here with their source formula visible.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    const AUDIT_ARCH_64BIT: u32 = 0x8000_0000;
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    const AUDIT_ARCH_LE: u32 = 0x4000_0000;
+
+    // Linux UAPI: `EM_*` values from include/uapi/linux/elf-em.h.
+    #[cfg(target_arch = "x86_64")]
+    const EM_X86_64: u32 = 62;
+    #[cfg(target_arch = "aarch64")]
+    const EM_AARCH64: u32 = 183;
+
+    #[cfg(target_arch = "x86_64")]
+    const AUDIT_ARCH: u32 = AUDIT_ARCH_64BIT | AUDIT_ARCH_LE | EM_X86_64;
+    #[cfg(target_arch = "aarch64")]
+    const AUDIT_ARCH: u32 = AUDIT_ARCH_64BIT | AUDIT_ARCH_LE | EM_AARCH64;
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::ffi::{CStr, CString};
+    use std::os::raw::{c_char, c_int};
+
+    use anyhow::{Context, Result};
+
+    const PROFILE: &str = r#"
+(version 1)
+(allow default)
+(deny process-exec)
+(deny network*)
+"#;
+
+    pub fn install() -> Result<()> {
+        let profile = CString::new(PROFILE).context("sandbox profile contains NUL byte")?;
+        let mut error: *mut c_char = std::ptr::null_mut();
+        let result = unsafe { sandbox_init(profile.as_ptr(), 0, &mut error) };
+
+        if result == -1 {
+            let message = if error.is_null() {
+                "unknown sandbox_init error".to_string()
+            } else {
+                let message = unsafe { CStr::from_ptr(error) }
+                    .to_string_lossy()
+                    .into_owned();
+                unsafe { sandbox_free_error(error) };
+                message
+            };
+            anyhow::bail!("sandbox_init failed: {message}");
+        }
+
+        Ok(())
+    }
+
+    #[link(name = "sandbox")]
+    unsafe extern "C" {
+        fn sandbox_init(profile: *const c_char, flags: u64, errorbuf: *mut *mut c_char) -> c_int;
+        fn sandbox_free_error(errorbuf: *mut c_char);
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod platform {
+    use anyhow::{Result, bail};
+
+    pub fn install() -> Result<()> {
+        bail!(
+            "process sandbox is not supported on {}",
+            std::env::consts::OS
+        );
+    }
+}

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -42,6 +42,25 @@ fn run_blend_in_cwd(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Out
         .expect("Failed to execute blend")
 }
 
+fn run_blend_with_env(
+    home: &Path,
+    blend_dir: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> std::process::Output {
+    let mut command = Command::new(blend_binary());
+    command
+        .args(args)
+        .arg("--home")
+        .arg(home)
+        .arg("--blend-dir")
+        .arg(blend_dir);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().expect("Failed to execute blend")
+}
+
 fn orders_dir(blend_dir: &Path) -> PathBuf {
     blend_dir.join("orders")
 }
@@ -83,6 +102,51 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
             std::fs::copy(entry.path(), &target).unwrap();
         }
     }
+}
+
+#[test]
+fn test_sandbox_never_ignores_debug_probe() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend_with_env(
+        home.path(),
+        &orders,
+        &["--sandbox", "never", "view", "--short", "toml-basic"],
+        &[("BLEND_SANDBOX_PROBE", "exec")],
+    );
+
+    assert!(
+        output.status.success(),
+        "--sandbox never should skip sandbox probe\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn test_sandbox_force_exec_probe() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend_with_env(
+        home.path(),
+        &orders,
+        &["--sandbox", "force", "view", "--short", "toml-basic"],
+        &[("BLEND_SANDBOX_PROBE", "exec")],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if output.status.success() {
+        return;
+    }
+
+    assert!(
+        stderr.contains("failed to enable process sandbox"),
+        "force mode should either enforce the exec probe or fail before work when sandbox is unavailable\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `--sandbox force|prefer|never` and matching `sandbox` config support, defaulting to `prefer`
- install the process sandbox before context setup/evaluation/writes; `force` fails closed, `prefer` warns and continues, and `never` skips sandboxing
- deny process execution and socket networking with Linux seccomp on x86_64/aarch64 and macOS Seatbelt
- keep `BLEND_SANDBOX_PROBE` behind debug assertions and cover force/never behavior with focused e2e tests

## Verification
- `cargo fmt --manifest-path blend/Cargo.toml --check`
- `cargo check --manifest-path blend/Cargo.toml`
- `cargo clippy --manifest-path blend/Cargo.toml -- -D warnings`
- `cargo test --manifest-path blend/Cargo.toml sandbox -- --nocapture`
- `cargo test --manifest-path blend/Cargo.toml --bins`
- `cargo build --manifest-path blend/Cargo.toml --release`
- release binary string scan confirms no `BLEND_SANDBOX_PROBE` / probe text is present