### PR TITLE
feat(blend): add check and format commands

### DIFF
--- a/.github/workflows/blend-ci.yml
+++ b/.github/workflows/blend-ci.yml
@@ -7,13 +7,13 @@ on:
       - "blend/**"
       - "Cargo.toml"
       - "Cargo.lock"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/blend-ci.yml"
   pull_request:
     paths:
       - "blend/**"
       - "Cargo.toml"
       - "Cargo.lock"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/blend-ci.yml"
 
 permissions:
   contents: read
@@ -42,5 +42,7 @@ jobs:
         with:
           workspaces: blend
       - run: cargo fmt --check
+      - run: cargo run -- check
+      - run: cargo run -- format --check
       - run: cargo clippy -- -D warnings
       - run: cargo test

--- a/.github/workflows/orders-ci.yml
+++ b/.github/workflows/orders-ci.yml
@@ -1,0 +1,67 @@
+name: orders CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "orders/**"
+      - ".github/workflows/orders-ci.yml"
+  pull_request:
+    paths:
+      - "orders/**"
+      - ".github/workflows/orders-ci.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Check changed paths
+        id: changed-paths
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename' > "$RUNNER_TEMP/changed-files"
+          else
+            gh api "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" --jq '.files[].filename' > "$RUNNER_TEMP/changed-files"
+          fi
+
+          only_orders=true
+          while IFS= read -r path; do
+            case "$path" in
+              orders/*) ;;
+              *) only_orders=false ;;
+            esac
+          done < "$RUNNER_TEMP/changed-files"
+
+          echo "only-orders=${only_orders}" >> "$GITHUB_OUTPUT"
+
+      - name: Install latest blend release
+        if: steps.changed-paths.outputs.only-orders == 'true'
+        run: |
+          set -eu
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl --proto '=https' --tlsv1.2 -fsSL https://github.com/frantic1048/Vanilla/releases/latest/download/blend-installer.sh -o "$RUNNER_TEMP/blend-installer.sh"
+          sh "$RUNNER_TEMP/blend-installer.sh" --dir "$RUNNER_TEMP/bin" --quiet
+          "$RUNNER_TEMP/bin/blend" --version
+
+      - name: Check orders
+        if: steps.changed-paths.outputs.only-orders == 'true'
+        run: '"$RUNNER_TEMP/bin/blend" check'
+
+      - name: Check order formatting
+        if: steps.changed-paths.outputs.only-orders == 'true'
+        run: '"$RUNNER_TEMP/bin/blend" format --check'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,14 +26,18 @@ Migration from the legacy nushell-based blend + `packages/` (stow-managed) to Ru
 
 ## blend Development
 
-blend is being enhanced iteratively via manual testing. No CI yet.
+blend is being enhanced iteratively via manual testing and CI.
+
+**Commit conventions:** use semantic/conventional commit subjects for changes to the blend program and its release/CI tooling (for example, `feat(blend): ...`, `fix(blend): ...`, `ci: ...`, `chore(blend): ...`).
+
+**Branch conventions:** development branches should use the `dev/*` namespace.
 
 **Pre-release posture:** blend is pre-initial-release with one user (the repo owner). Backwards compatibility is *not* a constraint — prefer the cleanest design over compat shims, deprecation paths, or migration tooling for hypothetical external users. Migrating the user's own dotfiles in this repo is still in scope.
 
 **Build / common tasks (via `just`):**
 ```sh
 just build         # cargo build --release + symlink target/release/blend → bin/blend
-just check         # blend view --dry-run (validates all orders)
+just check         # blend check (validates all orders)
 just test          # cargo test --release
 just fmt-check     # rustfmt --check
 just clippy        # cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +110,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +180,7 @@ dependencies = [
  "json-strip-comments",
  "libc",
  "nickel-lang",
+ "nickel-lang-core",
  "nickel-lang-parser",
  "rayon",
  "regex",
@@ -359,6 +399,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +488,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +596,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
@@ -557,10 +697,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -576,6 +731,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json-strip-comments"
@@ -613,7 +778,7 @@ dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
- "itertools",
+ "itertools 0.14.0",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -720,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
 dependencies = [
  "hashbrown 0.16.1",
- "itertools",
+ "itertools 0.14.0",
  "libm",
  "ryu",
 ]
@@ -731,7 +896,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d5021773c1552820b10ce7410817fadc1dfcef907b4f9a29af5346d756fd28"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
  "malachite-q",
@@ -744,7 +909,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "libm",
  "malachite-base",
  "serde",
@@ -757,7 +922,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2add95162aede090c48f0ee51bea7d328847ce3180aa44588111f846cc116b"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
  "serde",
@@ -778,6 +943,45 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -841,6 +1045,9 @@ dependencies = [
  "strsim",
  "toml 0.9.11+spec-1.1.0",
  "toml_edit 0.24.0+spec-1.1.0",
+ "topiary-core",
+ "topiary-queries",
+ "tree-sitter-nickel",
  "typed-arena",
  "unicode-segmentation",
 ]
@@ -894,6 +1101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +1144,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -984,6 +1206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1226,25 @@ dependencies = [
  "arrayvec",
  "typed-arena",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "prettydiff"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9a475bdea0881b8c65eb81f91fe53187b8522352a701b919c5a2c8a2f262808"
+dependencies = [
+ "owo-colors",
 ]
 
 [[package]]
@@ -1107,6 +1354,12 @@ dependencies = [
  "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
@@ -1299,6 +1552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1603,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1666,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1699,27 @@ name = "thiserror-impl"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1499,10 +1820,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
-name = "tree-sitter"
-version = "0.25.10"
+name = "topiary-core"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "89df094e19f103c5b8e120a1ffa30a6309daa10bef8d186e598a3df633e6a221"
+dependencies = [
+ "futures",
+ "itertools 0.11.0",
+ "log",
+ "miette",
+ "pretty_assertions",
+ "prettydiff",
+ "rayon",
+ "serde",
+ "serde_json",
+ "streaming-iterator",
+ "thiserror",
+ "tokio",
+ "topiary-tree-sitter-facade",
+ "topiary-web-tree-sitter-sys",
+ "tree-sitter",
+]
+
+[[package]]
+name = "topiary-queries"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13439d04bb7987de5f937071c8131c995f3d18fcc0df6ce4ab33180a88fbc72c"
+
+[[package]]
+name = "topiary-tree-sitter-facade"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b7f801962f0e1d022f78a46c6afa2d2158138a3955dbbd25bb92cc5ef61ddb"
+dependencies = [
+ "js-sys",
+ "streaming-iterator",
+ "topiary-web-tree-sitter-sys",
+ "tree-sitter",
+ "tree-sitter-language",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "topiary-web-tree-sitter-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9877bfc1ad20d17e6da579911925768df2edd6e276300d660265940881d7b9d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",
@@ -1546,6 +1923,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1615,6 +1998,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/NEW_BLEND.md
+++ b/NEW_BLEND.md
@@ -336,6 +336,9 @@ blend view [orders...]             Preview diffs (read-only)
 blend view -c [orders...]          Show generated content only (no diff)
 blend view -a [orders...]          Show both content and diff
 blend view -s [orders...]          Short mode: omit up-to-date entries
+blend check [orders...]            Typecheck/evaluate order.ncl files
+blend format [orders...]           Format order.ncl files
+blend format --check [orders...]   Check order.ncl formatting without writing
 blend table                        Output order info as HTML table (for README)
 blend init                         Generate/refresh orders contract + metadata files
 ```
@@ -458,7 +461,6 @@ In `.ncl` files, use `\u{xxxx}` escape sequences for non-ASCII characters (e.g.,
 
 - **Richer deploy state** — extend snapshots with order/file identity, timestamps, machine identity, and deployment mode for better diagnostics and old-target cleanup
 - **Secrets management** — integration with system keychains or sops
-- **Standalone validation command** — a first-class `blend check`/`blend lint` command rather than relying on `blend view --dry-run` or the top-level `just check`
 - **INI format renderer** — for git config and similar `[section]` formats
 - **`--no-rewrite` info display** — show branch context and Nickel snippets when Target -> Source rewrite is disabled
 - **Full YAML parser/renderer** — current `Yaml` uses JSON-compatible output and JSON/JSONC parsing

--- a/blend/Cargo.toml
+++ b/blend/Cargo.toml
@@ -13,6 +13,7 @@ console = "0.15"
 
 # Nickel DSL
 nickel-lang = "=2.1.0"
+nickel-lang-core = { version = "=0.17.0", default-features = false, features = ["format"] }
 nickel-lang-parser = "=0.2.0"
 codespan = "0.11"
 
@@ -35,7 +36,7 @@ libc = "0.2"
 rayon = "1"
 
 # Tree-sitter (CST structural parsing)
-tree-sitter = "0.25"
+tree-sitter = "0.26"
 tree-sitter-nickel = "0.5"
 
 # Error handling

--- a/blend/src/cli.rs
+++ b/blend/src/cli.rs
@@ -73,6 +73,23 @@ pub enum Commands {
         short: bool,
     },
 
+    /// Typecheck order.ncl files with Nickel
+    Check {
+        /// Orders to check (default: all)
+        orders: Vec<String>,
+    },
+
+    /// Format order.ncl files with Nickel
+    #[command(alias = "fmt")]
+    Format {
+        /// Orders to format (default: all)
+        orders: Vec<String>,
+
+        /// Check formatting without writing changes
+        #[arg(long)]
+        check: bool,
+    },
+
     /// Output order info as HTML table (for README generation)
     Table,
 

--- a/blend/src/commands.rs
+++ b/blend/src/commands.rs
@@ -1,3 +1,5 @@
+pub mod check;
+pub mod format;
 pub mod helpers;
 pub mod init;
 pub mod status;
@@ -5,6 +7,8 @@ pub mod sync;
 pub mod table;
 pub mod view;
 
+pub use check::cmd_check;
+pub use format::cmd_format;
 pub use init::cmd_init;
 pub use status::cmd_status;
 pub use sync::cmd_sync;

--- a/blend/src/commands/check.rs
+++ b/blend/src/commands/check.rs
@@ -1,0 +1,88 @@
+use console::style;
+
+use crate::compose::discover_orders;
+use crate::context::Context;
+use crate::nickel::{NickelEvaluator, Order, generated};
+use crate::output::log;
+
+fn selected_orders(ctx: &Context, orders: &[String]) -> Vec<String> {
+    let mut selected: Vec<String> = if orders.is_empty() {
+        discover_orders(&ctx.orders_dir).into_iter().collect()
+    } else {
+        orders.to_vec()
+    };
+    selected.sort();
+    selected
+}
+
+fn validate_order_semantics(ctx: &Context, order_name: &str, order: &Order) -> anyhow::Result<()> {
+    if !order.should_apply(&ctx.metadata.os, &ctx.metadata.arch, &ctx.metadata.hostname) {
+        return Ok(());
+    }
+
+    let order_dir = ctx.orders_dir.join(order_name);
+
+    for file_entry in &order.blend.files {
+        if !file_entry.should_apply(&ctx.metadata.os, &ctx.metadata.arch, &ctx.metadata.hostname) {
+            continue;
+        }
+
+        let Some(from_file) = &file_entry.from_file else {
+            continue;
+        };
+
+        let source_path = order_dir.join(from_file);
+        if !source_path.exists() {
+            anyhow::bail!(
+                "File entry '{}': source file not found at {}",
+                file_entry.name,
+                source_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Check command: typecheck and evaluate order.ncl files through Nickel.
+pub fn cmd_check(ctx: &Context, orders: &[String]) -> anyhow::Result<()> {
+    generated::assert_orders_ready(&ctx.orders_dir)?;
+
+    let evaluator = NickelEvaluator::new(&ctx.metadata);
+    let selected = selected_orders(ctx, orders);
+    let checking_specific = !orders.is_empty();
+    let mut checked = 0usize;
+    let mut failed = false;
+
+    for order_name in &selected {
+        let ncl_path = ctx.orders_dir.join(order_name).join("order.ncl");
+        if !ncl_path.exists() {
+            log::error(&format!("Order '{order_name}' not found"));
+            failed = true;
+            continue;
+        }
+
+        match evaluator.evaluate(&ncl_path).and_then(|order| {
+            validate_order_semantics(ctx, order_name, &order)?;
+            Ok(order)
+        }) {
+            Ok(_) => {
+                checked += 1;
+                if ctx.verbose || checking_specific {
+                    println!("{} {}", style("\u{2713}").green(), order_name);
+                }
+            }
+            Err(err) => {
+                failed = true;
+                log::error(&format!("{order_name}: {err:#}"));
+            }
+        }
+    }
+
+    if failed {
+        anyhow::bail!("Nickel check failed");
+    }
+
+    log::success(&format!("Checked {checked} order(s)"));
+    Ok(())
+}

--- a/blend/src/commands/format.rs
+++ b/blend/src/commands/format.rs
@@ -1,0 +1,83 @@
+use console::style;
+
+use crate::compose::discover_orders;
+use crate::context::Context;
+use crate::nickel::{format_source, generated};
+use crate::output::log;
+
+fn selected_orders(ctx: &Context, orders: &[String]) -> Vec<String> {
+    let mut selected: Vec<String> = if orders.is_empty() {
+        discover_orders(&ctx.orders_dir).into_iter().collect()
+    } else {
+        orders.to_vec()
+    };
+    selected.sort();
+    selected
+}
+
+/// Format command: format order.ncl files with Nickel's in-process formatter.
+pub fn cmd_format(ctx: &Context, orders: &[String], check: bool) -> anyhow::Result<()> {
+    generated::assert_orders_ready(&ctx.orders_dir)?;
+
+    let selected = selected_orders(ctx, orders);
+    let mut visited = 0usize;
+    let mut changed = Vec::new();
+    let mut failed = false;
+
+    for order_name in &selected {
+        let ncl_path = ctx.orders_dir.join(order_name).join("order.ncl");
+        if !ncl_path.exists() {
+            log::error(&format!("Order '{order_name}' not found"));
+            failed = true;
+            continue;
+        }
+
+        visited += 1;
+        let source = std::fs::read_to_string(&ncl_path)
+            .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", ncl_path.display()))?;
+        let formatted = format_source(&source)
+            .map_err(|e| anyhow::anyhow!("Failed to format {}: {e:#}", ncl_path.display()))?;
+
+        if formatted == source {
+            if ctx.verbose {
+                println!("{} {}", style("\u{2713}").green(), ncl_path.display());
+            }
+            continue;
+        }
+
+        changed.push(ncl_path.clone());
+        let action = if check || ctx.dry_run {
+            "would format"
+        } else {
+            "formatting"
+        };
+        println!("{} {}", style(action).yellow(), ncl_path.display());
+
+        if !check && !ctx.dry_run {
+            std::fs::write(&ncl_path, formatted)
+                .map_err(|e| anyhow::anyhow!("Failed to write {}: {e}", ncl_path.display()))?;
+        }
+    }
+
+    if failed {
+        anyhow::bail!("Nickel format failed");
+    }
+
+    if check && !changed.is_empty() {
+        anyhow::bail!("{} order.ncl file(s) need formatting", changed.len());
+    }
+
+    if ctx.dry_run && !changed.is_empty() {
+        log::info("Dry run: no files were written");
+    } else if !check {
+        log::success(&format!("Formatted {} order.ncl file(s)", changed.len()));
+    }
+
+    if check && changed.is_empty() {
+        log::success(&format!(
+            "Checked formatting for {visited} order.ncl file(s)"
+        ));
+    }
+
+    Ok(())
+}

--- a/blend/src/main.rs
+++ b/blend/src/main.rs
@@ -15,7 +15,7 @@ mod sync;
 use clap::Parser;
 
 use cli::{Cli, Commands};
-use commands::{cmd_init, cmd_status, cmd_sync, cmd_table, cmd_view};
+use commands::{cmd_check, cmd_format, cmd_init, cmd_status, cmd_sync, cmd_table, cmd_view};
 use context::{Context, sandbox_mode_from_cli_and_config};
 use output::log;
 use sandbox::SandboxMode;
@@ -103,6 +103,8 @@ fn main() {
             all,
             short,
         }) => cmd_view(&ctx, &orders, content_only, all, short),
+        Some(Commands::Check { orders }) => cmd_check(&ctx, &orders),
+        Some(Commands::Format { orders, check }) => cmd_format(&ctx, &orders, check),
         Some(Commands::Table) => cmd_table(&ctx),
         Some(Commands::Init) => cmd_init(&ctx),
         None => cmd_status(&ctx),

--- a/blend/src/nickel.rs
+++ b/blend/src/nickel.rs
@@ -4,5 +4,5 @@ mod loader;
 mod schema;
 pub mod structure_map;
 
-pub use loader::NickelEvaluator;
+pub use loader::{NickelEvaluator, format_source};
 pub use schema::{FileEntry, Format, Order};

--- a/blend/src/nickel/loader.rs
+++ b/blend/src/nickel/loader.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsString;
+use std::io::Cursor;
 use std::path::Path;
 
 use anyhow::{Context as AnyhowContext, Result};
@@ -7,6 +8,14 @@ use nickel_lang::Context;
 use crate::metadata::Metadata;
 
 use super::schema::Order;
+
+/// Format Nickel source using Nickel's in-process formatter.
+pub fn format_source(source: &str) -> Result<String> {
+    let mut output = Vec::new();
+    nickel_lang_core::format::format(Cursor::new(source.as_bytes()), &mut output)
+        .map_err(|e| anyhow::anyhow!("Nickel formatting error: {e}"))?;
+    String::from_utf8(output).with_context(|| "Nickel formatter emitted invalid UTF-8")
+}
 
 /// Nickel evaluator with metadata injection
 pub struct NickelEvaluator {

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -150,6 +150,109 @@ fn test_sandbox_force_exec_probe() {
 }
 
 #[test]
+fn test_check_order_success() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend(
+        home.path(),
+        &orders,
+        &["--sandbox", "never", "check", "toml-basic"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend check failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("Checked 1 order(s)"));
+}
+
+#[test]
+fn test_check_order_fails_when_from_file_is_missing() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("plaintext-single");
+    std::fs::remove_file(orders_dir(blend_dir.path()).join("plaintext-single/config.txt")).unwrap();
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["--sandbox", "never", "check", "plaintext-single"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "blend check should fail for missing from_file\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("source file not found"),
+        "missing from_file error should mention the missing source\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_format_check_order_success() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend(
+        home.path(),
+        &orders,
+        &["--sandbox", "never", "format", "--check", "toml-basic"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend format --check failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("Checked formatting for 1 order.ncl file(s)"));
+}
+
+#[test]
+fn test_format_order_writes_changes() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("toml-basic");
+    let order_path = orders_dir(blend_dir.path()).join("toml-basic/order.ncl");
+    let compact = r#"{ blend = { prefix = ["~/.config/toml-basic/"], files = [{ name = "config.toml", from_config = { key = "value", number = 42, nested = { inner = true, }, }, }], }, }"#;
+    std::fs::write(&order_path, compact).unwrap();
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["--sandbox", "never", "format", "toml-basic"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend format failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("Formatted 1 order.ncl file(s)"));
+
+    let formatted = std::fs::read_to_string(&order_path).unwrap();
+    assert_ne!(formatted, compact);
+    assert!(formatted.contains("files = ["));
+
+    let check = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["--sandbox", "never", "format", "--check", "toml-basic"],
+    );
+    assert!(
+        check.status.success(),
+        "formatted order should pass format --check\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+}
+
+#[test]
 fn test_sync_force_source_to_target_plain_data_new_file() {
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ build-debug:
 
 # Validate all orders
 check:
-    bin/blend view --dry-run
+    bin/blend check
 
 # Run rustfmt on the blend crate
 fmt:

--- a/orders/X/order.ncl
+++ b/orders/X/order.ncl
@@ -1,5 +1,4 @@
 # X11 configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/alsa/order.ncl
+++ b/orders/alsa/order.ncl
@@ -1,5 +1,4 @@
 # ALSA audio configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/bat/order.ncl
+++ b/orders/bat/order.ncl
@@ -1,6 +1,5 @@
 # bat configuration
 # https://github.com/sharkdp/bat
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/bin/order.ncl
+++ b/orders/bin/order.ncl
@@ -1,5 +1,4 @@
 # User scripts
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/color/order.ncl
+++ b/orders/color/order.ncl
@@ -1,5 +1,4 @@
 # Display color profiles (ICC)
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/elvish/order.ncl
+++ b/orders/elvish/order.ncl
@@ -1,6 +1,5 @@
 # Elvish shell configuration
 # https://elv.sh/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/fastfetch/order.ncl
+++ b/orders/fastfetch/order.ncl
@@ -1,6 +1,5 @@
 # Fastfetch configuration
 # https://github.com/fastfetch-cli/fastfetch
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/fcitx/order.ncl
+++ b/orders/fcitx/order.ncl
@@ -1,5 +1,4 @@
 # Fcitx input method configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/fontconfig/order.ncl
+++ b/orders/fontconfig/order.ncl
@@ -1,5 +1,4 @@
 # Fontconfig configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/ghostty/order.ncl
+++ b/orders/ghostty/order.ncl
@@ -1,6 +1,5 @@
 # Ghostty terminal configuration
 # https://ghostty.org/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/gpg/order.ncl
+++ b/orders/gpg/order.ncl
@@ -1,5 +1,4 @@
 # GnuPG configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/i3wm/order.ncl
+++ b/orders/i3wm/order.ncl
@@ -1,6 +1,5 @@
 # i3 window manager configuration
 # https://i3wm.org/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/macos-hushlogin/order.ncl
+++ b/orders/macos-hushlogin/order.ncl
@@ -1,5 +1,4 @@
 # Suppress the "Last login" banner in new macOS terminal sessions.
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/makepkg/order.ncl
+++ b/orders/makepkg/order.ncl
@@ -1,5 +1,4 @@
 # makepkg configuration (Arch Linux)
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/mako/order.ncl
+++ b/orders/mako/order.ncl
@@ -1,6 +1,5 @@
 # Mako notification daemon configuration
 # https://github.com/emersion/mako
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/mise/order.ncl
+++ b/orders/mise/order.ncl
@@ -1,6 +1,5 @@
 # mise configuration
 # https://mise.jdx.dev/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/nano/order.ncl
+++ b/orders/nano/order.ncl
@@ -1,5 +1,4 @@
 # nano text editor configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/ncdu/order.ncl
+++ b/orders/ncdu/order.ncl
@@ -1,6 +1,5 @@
 # ncdu disk usage analyzer configuration
 # https://dev.yorhel.nl/ncdu
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/neofetch/order.ncl
+++ b/orders/neofetch/order.ncl
@@ -1,5 +1,4 @@
 # Neofetch configuration (deprecated)
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/neovim/order.ncl
+++ b/orders/neovim/order.ncl
@@ -1,13 +1,12 @@
 # Neovim configuration (plaintext)
 # Source files are copied as-is to target
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {
     prefix = ["~/.config/"],
     files = [
       {
-        from_file = "nvim",  # Copy orders/neovim/nvim/ to target
+        from_file = "nvim", # Copy orders/neovim/nvim/ to target
         # No config section - source directory copied as-is
       },
     ],

--- a/orders/npm/order.ncl
+++ b/orders/npm/order.ncl
@@ -1,5 +1,4 @@
 # npm configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/pam_env/order.ncl
+++ b/orders/pam_env/order.ncl
@@ -1,5 +1,4 @@
 # PAM environment configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/picom/order.ncl
+++ b/orders/picom/order.ncl
@@ -1,6 +1,5 @@
 # Picom compositor configuration
 # https://github.com/yshui/picom
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/pipewire/order.ncl
+++ b/orders/pipewire/order.ncl
@@ -1,5 +1,4 @@
 # PipeWire audio configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/proto/order.ncl
+++ b/orders/proto/order.ncl
@@ -1,6 +1,5 @@
 # Proto toolchain manager configuration
 # https://moonrepo.dev/proto
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/pueue/order.ncl
+++ b/orders/pueue/order.ncl
@@ -1,6 +1,5 @@
 # Pueue task manager configuration
 # https://github.com/Nukesor/pueue
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/pulseaudio/order.ncl
+++ b/orders/pulseaudio/order.ncl
@@ -1,5 +1,4 @@
 # PulseAudio configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/rofi/order.ncl
+++ b/orders/rofi/order.ncl
@@ -1,6 +1,5 @@
 # Rofi application launcher configuration
 # https://github.com/davatorium/rofi
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/sakura/order.ncl
+++ b/orders/sakura/order.ncl
@@ -1,5 +1,4 @@
 # Sakura terminal configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/sketchybar/order.ncl
+++ b/orders/sketchybar/order.ncl
@@ -1,6 +1,5 @@
 # SketchyBar configuration
 # https://felixkratz.github.io/SketchyBar/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/skhd/order.ncl
+++ b/orders/skhd/order.ncl
@@ -1,6 +1,5 @@
 # skhd hotkey daemon configuration
 # https://github.com/koekeishiya/skhd
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/sway/order.ncl
+++ b/orders/sway/order.ncl
@@ -1,6 +1,5 @@
 # Sway Wayland compositor configuration
 # https://swaywm.org/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/swayshot/order.ncl
+++ b/orders/swayshot/order.ncl
@@ -1,5 +1,4 @@
 # Swayshot screenshot tool configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/sxiv/order.ncl
+++ b/orders/sxiv/order.ncl
@@ -1,5 +1,4 @@
 # sxiv image viewer configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/tealdeer/order.ncl
+++ b/orders/tealdeer/order.ncl
@@ -1,6 +1,5 @@
 # tealdeer (tldr client) configuration
 # https://dbrgn.github.io/tealdeer/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/tint2/order.ncl
+++ b/orders/tint2/order.ncl
@@ -1,5 +1,4 @@
 # tint2 panel configuration
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/waybar/order.ncl
+++ b/orders/waybar/order.ncl
@@ -1,6 +1,5 @@
 # Waybar status bar configuration
 # https://github.com/Alexays/Waybar
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/wezterm/order.ncl
+++ b/orders/wezterm/order.ncl
@@ -1,6 +1,5 @@
 # WezTerm terminal configuration
 # https://wezfurlong.org/wezterm/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/yabai/order.ncl
+++ b/orders/yabai/order.ncl
@@ -1,6 +1,5 @@
 # yabai tiling window manager configuration
 # https://github.com/koekeishiya/yabai
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {

--- a/orders/zellij/order.ncl
+++ b/orders/zellij/order.ncl
@@ -1,6 +1,5 @@
 # Zellij terminal multiplexer configuration (macOS)
 # https://zellij.dev/documentation/
-
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {


### PR DESCRIPTION
## Summary
- add `blend check` to evaluate/typecheck selected or all `order.ncl` files through the embedded Nickel evaluator
- validate order semantics in `blend check`, including missing active `from_file` sources
- add `blend format` / `blend fmt` with `--check` and dry-run support using the in-process Nickel formatter
- dogfood both commands in scoped blend CI under the default sandbox policy and commit the current Nickel formatter baseline for existing orders
- split orders-only CI into a separate workflow that installs the latest blend release and runs `blend check` plus `blend format --check`
- update docs and `just check`, and cover the new commands in E2E tests

Closes #22.

## Verification
- `actionlint .github/workflows/blend-ci.yml .github/workflows/orders-ci.yml`
- `cargo fmt -p blend --check`
- `cargo test -p blend test_check_order`
- `cargo test -p blend`
- `HOME=/private/tmp/blend-ci-home-semantics cargo run -p blend -- check`
- `HOME=/private/tmp/blend-ci-home-semantics cargo run -p blend -- format --check`
