### PR TITLE
Improve Blend CLI help discoverability

### DIFF
--- a/blend/src/cli.rs
+++ b/blend/src/cli.rs
@@ -3,17 +3,48 @@ use std::path::PathBuf;
 
 use crate::sandbox::SandboxMode;
 
+const LONG_ABOUT: &str = "\
+Cross-platform dotfiles manager with Nickel DSL
+
+Tags: [read] writes nothing; [source] writes Blend Source files; [target] writes deployed files or Blend runtime state.";
+
+const HELP_TEMPLATE: &str = "\
+{about}
+
+{usage-heading} {usage}{after-help}
+Options:
+{options}";
+
+const COMMAND_HELP: &str = "\
+Inspect:
+  status  [read] Show order deployment status (default)
+  view    [read] Preview generated config and diff from Target files
+  table   [read] Output order info as HTML table
+
+Maintain:
+  check   [read] Validate Source order definitions
+  format  [source] Format Source order files
+  init    [source, target] Initialize or refresh Blend metadata and config
+  sync    [source, target] Reconcile Source orders and Target files
+
+Other:
+  help    Print this message or the help of the given subcommand(s)
+";
+
 #[derive(Parser)]
 #[command(
     name = "blend",
     version,
-    about = "Cross-platform dotfiles manager with Nickel DSL"
+    about = "Cross-platform dotfiles manager with Nickel DSL",
+    long_about = LONG_ABOUT,
+    help_template = HELP_TEMPLATE,
+    after_help = COMMAND_HELP
 )]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
 
-    /// Show what would be done without making changes
+    /// Preview mutating commands without writing files
     #[arg(short = 'n', long, global = true)]
     pub dry_run: bool,
 
@@ -25,7 +56,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub home: Option<PathBuf>,
 
-    /// Override blend directory (the parent directory that contains orders/)
+    /// Override Blend Source root; default: nearest ancestor with orders/, then remembered state
     #[arg(long = "blend-dir", global = true)]
     pub blend_dir: Option<PathBuf>,
 
@@ -36,32 +67,25 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Bidirectional sync between Source (orders) and Target (deployed files)
-    #[command(alias = "s")]
-    Sync {
-        /// Orders to sync (default: all)
-        orders: Vec<String>,
+    #[command(flatten)]
+    Inspect(InspectCommands),
 
-        /// Force-resolve: apply all Source values to Targets without prompting
-        #[arg(long = "force-source-to-target")]
-        force_source_to_target: bool,
+    #[command(flatten)]
+    Maintain(MaintainCommands),
+}
 
-        /// Force-resolve: apply all Target values back to Source without prompting
-        #[arg(long = "force-target-to-source")]
-        force_target_to_source: bool,
+#[derive(Subcommand)]
+pub enum InspectCommands {
+    /// [read] Show order deployment status (default)
+    Status,
 
-        /// Disable .ncl rewrite when applying Target to Source; show diff for manual merge
-        #[arg(long)]
-        no_rewrite: bool,
-    },
-
-    /// Preview generated config and diff from deployed
+    /// [read] Preview generated config and diff from Target files
     View {
         /// Orders to view (default: all)
         orders: Vec<String>,
 
         /// Only show generated content (no diff)
-        #[arg(short = 'c', long)]
+        #[arg(short = 'c', long, conflicts_with = "all")]
         content_only: bool,
 
         /// Show both generated content and diff
@@ -73,13 +97,41 @@ pub enum Commands {
         short: bool,
     },
 
-    /// Typecheck order.ncl files with Nickel
+    /// [read] Output order info as HTML table
+    Table,
+}
+
+#[derive(Subcommand)]
+pub enum MaintainCommands {
+    /// [source, target] Reconcile Source orders and Target files
+    #[command(alias = "s")]
+    Sync {
+        /// Orders to sync (default: all)
+        orders: Vec<String>,
+
+        /// Force-resolve: apply all Source values to Targets without prompting
+        #[arg(
+            long = "force-source-to-target",
+            conflicts_with = "force_target_to_source"
+        )]
+        force_source_to_target: bool,
+
+        /// Force-resolve: apply all Target values back to Source without prompting
+        #[arg(long = "force-target-to-source")]
+        force_target_to_source: bool,
+
+        /// Disable .ncl rewrite when applying Target to Source; show diff for manual merge
+        #[arg(long)]
+        no_rewrite: bool,
+    },
+
+    /// [read] Validate Source order definitions
     Check {
         /// Orders to check (default: all)
         orders: Vec<String>,
     },
 
-    /// Format order.ncl files with Nickel
+    /// [source] Format Source order files
     #[command(alias = "fmt")]
     Format {
         /// Orders to format (default: all)
@@ -90,10 +142,11 @@ pub enum Commands {
         check: bool,
     },
 
-    /// Output order info as HTML table (for README generation)
-    Table,
+    /// [source, target] Initialize or refresh Blend metadata and config
+    #[command(long_about = "\
+[source, target] Initialize or refresh Blend metadata and config
 
-    /// Generate or refresh orders/order.contract.ncl and orders/metadata.ncl
+Writes or refreshes orders/order.contract.ncl and orders/metadata.ncl. For a new Source root, also creates a starter blend order and deploys its config to Target. If no Source root is found, init bootstraps the current directory.")]
     Init {
         /// Apply breaking contract migrations (required when upgrading across breaking versions)
         #[arg(long)]

--- a/blend/src/context.rs
+++ b/blend/src/context.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context as AnyhowContext, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::cli::{Cli, Commands};
+use crate::cli::{Cli, Commands, MaintainCommands};
 use crate::metadata::Metadata;
 use crate::output::log;
 use crate::sandbox::SandboxMode;
@@ -95,7 +95,10 @@ fn resolve_blend_dir(cli: &Cli, state: &StateStore) -> Result<BlendDirChoice> {
         });
     }
 
-    if matches!(cli.command, Some(Commands::Init { .. })) {
+    if matches!(
+        cli.command,
+        Some(Commands::Maintain(MaintainCommands::Init { .. }))
+    ) {
         if let Some(current) = find_blend_dir_from_current_dir() {
             return choice_from_current_dir(state, current);
         }

--- a/blend/src/context.rs
+++ b/blend/src/context.rs
@@ -39,7 +39,8 @@ impl Context {
             verbose: cli.verbose,
             metadata,
             state,
-            update_config_after_success: blend_dir_choice.update_config_after_success,
+            update_config_after_success: blend_dir_choice.update_config_after_success
+                && command_can_update_blend_dir_state(cli),
         })
     }
 
@@ -132,6 +133,15 @@ fn find_blend_dir(state: &StateStore) -> Result<BlendDirChoice> {
     }
 
     bail!("Could not find blend directory. Run from a blend checkout or pass --blend-dir <PATH>.")
+}
+
+fn command_can_update_blend_dir_state(cli: &Cli) -> bool {
+    matches!(
+        cli.command,
+        Some(Commands::Maintain(MaintainCommands::Sync { .. }))
+            | Some(Commands::Maintain(MaintainCommands::Format { .. }))
+            | Some(Commands::Maintain(MaintainCommands::Init { .. }))
+    )
 }
 
 fn choice_from_current_dir(state: &StateStore, current: PathBuf) -> Result<BlendDirChoice> {

--- a/blend/src/main.rs
+++ b/blend/src/main.rs
@@ -15,7 +15,7 @@ mod sync;
 
 use clap::Parser;
 
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, InspectCommands, MaintainCommands};
 use commands::{cmd_check, cmd_format, cmd_init, cmd_status, cmd_sync, cmd_table, cmd_view};
 use context::{Context, sandbox_mode_from_cli_and_config};
 use output::log;
@@ -83,12 +83,13 @@ fn main() {
     }
 
     let result = match cli.command {
-        Some(Commands::Sync {
+        Some(Commands::Inspect(InspectCommands::Status)) => cmd_status(&ctx),
+        Some(Commands::Maintain(MaintainCommands::Sync {
             orders,
             force_source_to_target,
             force_target_to_source,
             no_rewrite,
-        }) => {
+        })) => {
             let mode = if force_source_to_target {
                 SyncMode::ApplySourceToTargetAll
             } else if force_target_to_source {
@@ -98,16 +99,18 @@ fn main() {
             };
             cmd_sync(&ctx, &orders, mode, no_rewrite, &TerminalPrompter)
         }
-        Some(Commands::View {
+        Some(Commands::Inspect(InspectCommands::View {
             orders,
             content_only,
             all,
             short,
-        }) => cmd_view(&ctx, &orders, content_only, all, short),
-        Some(Commands::Check { orders }) => cmd_check(&ctx, &orders),
-        Some(Commands::Format { orders, check }) => cmd_format(&ctx, &orders, check),
-        Some(Commands::Table) => cmd_table(&ctx),
-        Some(Commands::Init { upgrade }) => cmd_init(&ctx, upgrade),
+        })) => cmd_view(&ctx, &orders, content_only, all, short),
+        Some(Commands::Maintain(MaintainCommands::Check { orders })) => cmd_check(&ctx, &orders),
+        Some(Commands::Maintain(MaintainCommands::Format { orders, check })) => {
+            cmd_format(&ctx, &orders, check)
+        }
+        Some(Commands::Inspect(InspectCommands::Table)) => cmd_table(&ctx),
+        Some(Commands::Maintain(MaintainCommands::Init { upgrade })) => cmd_init(&ctx, upgrade),
         None => cmd_status(&ctx),
     };
 

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -426,6 +426,121 @@ fn test_status_shows_orders() {
 }
 
 #[test]
+fn test_status_subcommand_shows_orders() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend(home.path(), &orders, &["status"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("toml-basic"),
+        "explicit status should list orders:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_help_groups_commands_and_documents_blend_dir_resolution() {
+    let output = Command::new(blend_binary())
+        .arg("--help")
+        .output()
+        .expect("Failed to execute blend");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend --help failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Inspect:"),
+        "missing Inspect group:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Maintain:"),
+        "missing Maintain group:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("status  [read] Show order deployment status (default)"),
+        "missing explicit status command:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("sync    [source, target] Reconcile Source orders and Target files"),
+        "missing sync safety tag:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("nearest ancestor with orders/, then remembered state"),
+        "missing blend-dir resolution docs:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_status_help_succeeds() {
+    let output = Command::new(blend_binary())
+        .args(["status", "-h"])
+        .output()
+        .expect("Failed to execute blend");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend status -h failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("[read] Show order deployment status (default)"),
+        "status help should describe the command:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_view_content_only_conflicts_with_all() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend(home.path(), &orders, &["view", "--content-only", "--all"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "conflicting view flags should fail:\nstdout: {}\nstderr: {stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains("--content-only") && stderr.contains("--all"),
+        "error should name both conflicting flags:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_sync_force_directions_conflict() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let output = run_blend(
+        home.path(),
+        &orders,
+        &[
+            "sync",
+            "--force-source-to-target",
+            "--force-target-to-source",
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "conflicting sync force flags should fail:\nstdout: {}\nstderr: {stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains("--force-source-to-target") && stderr.contains("--force-target-to-source"),
+        "error should name both conflicting flags:\n{stderr}"
+    );
+}
+
+#[test]
 fn test_status_shows_order_when_first_file_entry_is_skipped() {
     let home = TempDir::new().unwrap();
     let temp = TempDir::new().unwrap();

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -1764,7 +1764,7 @@ fn test_commands_use_configured_blend_dir_outside_checkout() {
 }
 
 #[test]
-fn test_valid_cwd_refreshes_stale_remembered_blend_dir() {
+fn test_read_command_uses_current_cwd_without_refreshing_stale_remembered_blend_dir() {
     let home = TempDir::new().unwrap();
     let stale = copy_fixture("plaintext-single");
     let current = copy_fixture("toml-basic");
@@ -1792,8 +1792,42 @@ fn test_valid_cwd_refreshes_stale_remembered_blend_dir() {
 
     let state = std::fs::read_to_string(state_dir.join("state.json")).unwrap();
     assert!(
+        state.contains(&stale.path().display().to_string()),
+        "read command should not refresh remembered blend dir, got:\n{state}",
+    );
+}
+
+#[test]
+fn test_mutating_command_refreshes_stale_remembered_blend_dir() {
+    let home = TempDir::new().unwrap();
+    let stale = copy_fixture("plaintext-single");
+    let current = copy_fixture("toml-basic");
+
+    // Seed a stale blend dir into state so it differs from the cwd checkout.
+    let state_dir = home.path().join(".local/state/blend");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::write(
+        state_dir.join("state.json"),
+        format!("{{\"blend_dir\":\"{}\"}}", stale.path().display()),
+    )
+    .unwrap();
+
+    let output = run_blend_in_cwd(home.path(), current.path(), &["format", "toml-basic"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "blend format should use the current checkout and succeed\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stdout.contains("differs from remembered blend-dir"),
+        "expected mismatch warning\nstdout: {stdout}",
+    );
+
+    let state = std::fs::read_to_string(state_dir.join("state.json")).unwrap();
+    assert!(
         state.contains(&current.path().display().to_string()),
-        "state should be refreshed to current checkout, got:\n{state}",
+        "mutating command should refresh state to current checkout, got:\n{state}",
     );
 }
 


### PR DESCRIPTION
## Summary
- expose `blend status` while keeping bare `blend` as the status default
- group top-level help by Inspect/Maintain with [read], [source], and [target] tags
- document `--blend-dir` Source-root resolution and `init` bootstrap behavior
- reject contradictory `view` and `sync` flag combinations
- keep read commands from refreshing remembered Blend Source state

## Validation
- `cargo fmt --check`
- `cargo clippy -p blend -- -D warnings`
- `cargo test -p blend`
- `cargo test -p blend --release`

## Summary by Sourcery

Improve Blend CLI help discoverability and clarify behavior around blend directory resolution and state updates.

New Features:
- Expose a dedicated `blend status` subcommand while keeping bare `blend` as the default status action.
- Introduce grouped top-level help output with Inspect/Maintain command categories and read/source/target safety tags.
- Add detailed documentation for `--blend-dir` source root resolution and `init` bootstrap behavior in CLI help text.

Bug Fixes:
- Reject conflicting `view --content-only --all` and `sync --force-source-to-target --force-target-to-source` flag combinations.
- Prevent read-only commands from refreshing remembered Blend Source state while ensuring mutating commands do refresh it.

Enhancements:
- Refactor CLI subcommands into Inspect and Maintain groups with clearer command descriptions and tags.
- Update global flags descriptions to better explain dry-run semantics and blend directory overrides.
- Adjust blend directory resolution to only persist state when commands can safely update it.

Tests:
- Add CLI help and status subcommand coverage, including command grouping and blend-dir documentation checks.
- Add tests for conflicting flag combinations and for state refresh behavior between read-only and mutating commands.