### PR TITLE
feat!(blend): add order create and add commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 
 Vanilla is the owner's dotfiles repository. Configs are defined as Nickel
 orders under `orders/` and deployed by the local `blend` CLI, a Rust tool in
-`blend/`. The root `bin/blend` entry is a symlink to the release build at
+`blend/`. The root `bin` entry is a symlink to `orders/bin/bin`, and
+`bin/blend` resolves through that Source directory to the release build at
 `target/release/blend`.
 
 This repo mixes two surfaces:
@@ -18,7 +19,7 @@ Keep those surfaces distinct when changing, testing, and interpreting CI.
 
 - `blend/` - Rust crate for the `blend` CLI.
 - `orders/` - active Nickel order definitions and config source files.
-- `bin/` - personal scripts deployed to `$PATH`, plus the `bin/blend` symlink.
+- `bin` - symlink to the physical personal-script Source at `orders/bin/bin`.
 - `legacy/` - stow-era or out-of-scope files kept for reference only; not
   managed by blend.
 - `screenshots/` - README screenshots.
@@ -86,7 +87,7 @@ Toolchain and dependency facts:
 Common tasks:
 
 ```sh
-just build       # release build + update bin/blend symlink
+just build       # release build + update the bin/blend entrypoint symlink
 just check       # bin/blend check
 just test        # cargo test --release in blend/
 just fmt-check   # cargo fmt --check in blend/
@@ -112,6 +113,10 @@ Inspect commands:
 Maintain commands:
 
 - `check [orders...]` - `[read]` validate Source order definitions.
+- `create <order>` - `[source]` scaffold a new empty Source order.
+- `add <order> <target>` - `[source]` import an absolute or `~`-prefixed
+  Target file/directory into an existing Source order. Useful flags:
+  `--prefix`, `--symlink follow|preserve`, `--allow-overlap`.
 - `format [orders...]` / `fmt` - `[source]` format Source order files; use
   `--check` in CI or review validation.
 - `init --upgrade` - `[source, target]` initialize or refresh
@@ -128,6 +133,13 @@ Global flags:
 - `--home` overrides Target `~` expansion and `metadata.home`.
 - `--blend-dir` overrides the Blend Source root.
 - `--sandbox force|prefer|never` controls the process sandbox policy.
+
+Order Source paths:
+
+- `from_file` and `local` are relative to their order directory and must not be
+  absolute or normalize outside that directory.
+- File entries need an effective Target prefix from either `blend.prefix` or
+  entry-level `prefix`.
 
 ## Source Map
 

--- a/ERGO.md
+++ b/ERGO.md
@@ -2,11 +2,12 @@
 
 ## Context
 
-Investigating the current blend implementation (at `~/Vanilla/blend/`) to map essential user journeys and identify friction points. blend is a Rust-based dotfiles manager using Nickel DSL, managing ~55 orders across macOS and Linux.
+Investigating the current blend implementation (at `~/Vanilla/blend/`) to map essential user journeys and identify friction points. blend is a Rust-based dotfiles manager using Nickel DSL, managing roughly 50 orders across macOS and Linux.
 
-**Current CLI commands:** default status, `sync` (alias `s`), `view`, `table`,
-and `init`. The previous `ship`, `sample`, and task/upgrade CLI paths have been
-removed or moved to the top-level `justfile`.
+**Current CLI commands:** default status, `status`, `view`, `table`, `check`,
+`create`, `add`, `format` (alias `fmt`), `init`, and `sync` (alias `s`). The
+previous `ship`, `sample`, and task/upgrade CLI paths have been removed or
+moved to the top-level `justfile`.
 
 ---
 
@@ -50,10 +51,11 @@ removed or moved to the top-level `justfile`.
 ### Current Flow
 
 ```
-1. Create dir:           mkdir orders/my-app
-2. Write order.ncl:      (manually, from memory or by copying another order)
-3. For plaintext:        cp ~/.config/my-app/config orders/my-app/config
-4. For structured:       Manually transcribe TOML/JSON/YAML into Nickel from_config syntax
+1. Scaffold order:       blend create my-app
+2. Import plaintext:     blend add my-app ~/.config/my-app/config
+   2a. Or explicit root: blend add my-app --prefix ~/.config/my-app ~/.config/my-app/config
+3. For structured:       Manually transcribe TOML/JSON/YAML into Nickel from_config syntax
+4. Validate:             blend check my-app
 5. Preview:              blend view my-app
 6. Deploy:               blend sync my-app
 ```
@@ -62,19 +64,18 @@ removed or moved to the top-level `justfile`.
 
 | # | Issue | Severity | Detail |
 |---|-------|----------|--------|
-| 1 | **No scaffolding command** | High | No `blend add my-app` to create order skeleton with boilerplate order.ncl |
+| 1 | **~~No scaffolding command~~** | ~~High~~ | **Resolved** — `blend create <order>` scaffolds the Source order and `blend add <order> <target>` imports existing Target files/directories |
 | 2 | **Manual config transcription for structured** | High | User must hand-convert a TOML/JSON file into Nickel `from_config = { ... }` syntax. For a 200-line starship.toml, this is painful and error-prone |
 | 3 | **Must know Nickel syntax** | Medium | No inline documentation, no `blend help new-order` with examples |
-| 4 | **No first-class validation command** | Low | `just check` wraps `bin/blend view --dry-run`, but there is no dedicated `blend check`/`blend lint` CLI yet |
+| 4 | **~~No first-class validation command~~** | ~~Low~~ | **Resolved** — `blend check [orders...]` validates Source order definitions without deploying |
 | 5 | **Schema contract usage is implicit** | Low | User should pipe to `| Order` at end of order.ncl for editor/Nickel validation, but the workflow does not strongly suggest it; Rust deserialization still validates the evaluated shape |
 
 ### Improvement Ideas
 
-- `blend add <name> [--from <path>]` command that:
-  - Creates `orders/<name>/order.ncl` with sensible defaults
-  - If `--from ~/.config/app/config.toml` is given: auto-detects format, parses the file, generates `from_config` Nickel syntax using `json_to_nickel()` (already implemented in `ast_utils.rs`)
-  - For directories: creates `from_file` entry pointing to copied dir
-- `blend check`: validate all order.ncl files without deploying (first-class CLI wrapper around fast Nickel eval + schema check)
+- ~~Order scaffolding/import~~: **Implemented** via `blend create <order>` and
+  `blend add <order> <target>` for `from_file` entries.
+- Structured import remains future work: auto-detect a TOML/JSON/YAML Target,
+  parse it, and generate `from_config` Nickel syntax using `json_to_nickel()`.
 
 ---
 
@@ -158,14 +159,14 @@ These friction points from the original analysis have been addressed by `blend s
 
 | # | Issue | Severity | Detail |
 |---|-------|----------|--------|
-| 1 | **No first-class validation-only command** | Medium | No `blend check` or `blend lint` CLI yet; the top-level `just check` currently uses `bin/blend view --dry-run` |
+| 1 | **~~No first-class validation-only command~~** | ~~Medium~~ | **Resolved** — `blend check [orders...]` validates Source order definitions without deploying |
 | 2 | **No rollback** | Medium | If a force deploy overwrites a config and breaks an app, there's no `blend rollback` or automatic backup |
 | 3 | **Nickel errors can be opaque** | Low | Nickel evaluation errors include source info but can be hard to trace for contract violations |
 | 4 | **No pre-sync backup** | Low | Sync overwrites in-place. A backup of the previous deployed version would help recovery |
 
 ### Improvement Ideas
 
-- `blend check`: validate all orders without building (fast Nickel eval + schema check)
+- ~~`blend check`~~: **Implemented** — validate all orders without deploying (fast Nickel eval + schema check)
 - Auto-backup before Source -> Target sync: copy previous Target file to `~/.cache/blend/backups/<order>/<file>.bak`
 - `blend rollback <order>`: restore from backup
 
@@ -176,10 +177,12 @@ These friction points from the original analysis have been addressed by `blend s
 ### Quick Wins (low effort, high impact)
 1. ~~**Fix bootstrap script**: install proto/Rust, build `bin/blend`, then deploy via `just bootstrap`~~
 2. **First-run message**: When all orders are pending, show "Run `blend sync` to review and deploy"
-3. **`blend check` command**: Validate all order.ncl files without deploying
+3. ~~**`blend check` command**~~: **Implemented** — validate all order.ncl files without deploying
 
 ### Medium Effort
-4. **`blend add <name> [--from <path>]`**: Scaffold new orders with auto-import from existing deployed configs (can reuse existing `json_to_nickel()` for format conversion). This covers the "capture existing config into a new order" use case — currently there's no way to pull a config from the filesystem into a new order without manual setup.
+4. ~~**`blend create` / `blend add` for `from_file` import**~~:
+   **Implemented** — remaining work is structured `from_config` import from
+   existing TOML/JSON/YAML Targets.
 5. **`--no-rewrite` info display**: Show branch context and Nickel snippets for manual merge
 6. **Suggest ignore patterns**: Auto-detect frequently changing fields
 
@@ -195,6 +198,9 @@ These friction points from the original analysis have been addressed by `blend s
 Features that were in "Improvement Ideas" and are now implemented:
 
 - **`blend sync`** — bidirectional sync with interactive Source/Target/skip choices (Journey 3, items 1/3/4)
+- **`blend check`** — validation-only Source order checks
+- **`blend create`** — scaffold an empty Source order
+- **`blend add`** — import existing Target files/directories as `from_file` entries
 - **`blend sync --force-source-to-target`** — non-interactive Source -> Target all
 - **`blend sync --force-target-to-source`** — non-interactive Target -> Source all
 - **Surgical .ncl rewrite** — auto-patches Nickel source for data-only and conditional values

--- a/NEW_BLEND.md
+++ b/NEW_BLEND.md
@@ -35,7 +35,7 @@ Two config modes per file entry:
 | Mode | Source | Rendering | Sync-back |
 |------|--------|-----------|-----------|
 | `from_config` | Inline Nickel data/expressions | Evaluated → rendered to target format | Context-aware AST rewrite |
-| `from_file` | Files/dirs in `orders/<order>/` | Copied as-is | File copy back |
+| `from_file` | Relative files/dirs inside `orders/<order>/` | Copied as-is | File copy back |
 
 ---
 
@@ -60,14 +60,14 @@ Each order is defined by `orders/<order>/order.ncl`. The evaluated result must c
 |-------|------|----------|-------------|
 | `name` | String | Yes (for `from_config`) | Destination filename. Combined with prefix for target path. Auto-set from `from_file` if omitted. |
 | `from_config` | Record/Array | One of these | Inline structured config data, evaluated by Nickel and rendered to target format |
-| `from_file` | String | One of these | Path to file/directory in the order dir, copied as-is |
-| `prefix` | Array<String> | No | Per-file prefix override (default: inherits global `blend.prefix`) |
+| `from_file` | String | One of these | Relative path to file/directory in the order dir, copied as-is. Absolute paths and paths that normalize outside the order dir are rejected. |
+| `prefix` | Array<String> | No | Per-file prefix override (default: inherits global `blend.prefix`). File entries require an effective prefix from either place. |
 | `format` | String | No | Output format override (default: inferred from `name` extension) |
 | `ignore` | Array<String> | No | Keys/patterns to exclude from diff (merged with global) |
 | `when` | Record | No | Per-file condition: `{ os, arch, hostname }` |
 | `symlink` | Bool | No | Create symlink instead of copying (`from_file` only) |
 | `exclude` | Array<String> | No | Glob patterns to skip in `from_file` directories |
-| `local` | String | No | Local overlay directory for machine-specific overrides (auto-created, gitignored) |
+| `local` | String | No | Relative local overlay directory for machine-specific overrides (auto-created, gitignored). It follows the same non-escaping Source path rule as `from_file`. |
 | `immutable` | Bool | No | Set OS immutable flag after deploying (macOS `chflags uchg`, Linux `chattr +i`) |
 
 ### Example: structured config (from_config)
@@ -325,7 +325,7 @@ Prompt diffs use explicit side markers instead of traditional `+/-`:
 
 ```
 blend                              Status: show all orders and sync state
-blend sync [orders...]             Interactive bidirectional sync (default)
+blend sync [orders...]             Interactive bidirectional sync
 blend s [orders...]                Alias for `blend sync`
 blend sync --force-source-to-target
                                    Force-apply Source values to Targets
@@ -337,6 +337,10 @@ blend view -c [orders...]          Show generated content only (no diff)
 blend view -a [orders...]          Show both content and diff
 blend view -s [orders...]          Short mode: omit up-to-date entries
 blend check [orders...]            Typecheck/evaluate order.ncl files
+blend create <order>               Scaffold an empty Source order
+blend add <order> <target>         Import a Target file/directory into an order
+blend add <order> --prefix <path> <target>
+                                   Strip an explicit Target prefix before import
 blend format [orders...]           Format order.ncl files
 blend format --check [orders...]   Check order.ncl formatting without writing
 blend table                        Output order info as HTML table (for README)
@@ -453,7 +457,7 @@ In `.ncl` files, use `\u{xxxx}` escape sequences for non-ASCII characters (e.g.,
 - **Three-way merge context**: Snapshot-backed prompts are implemented for conflict explanation. This is not a full automatic merge engine, but `blend` can now show Source/Target/Base context when a snapshot exists.
 - **Secrets management**: Deferred to v2. Focus on core config management first.
 - **JSONC round-trip**: Output JSON without comments. Comments live in Nickel source.
-- **Schema validation**: Orders are validated through the Nickel `| Order` contract when present, then through Rust deserialization and `resolve_defaults()`. Generated `order.contract.ncl` and `metadata.ncl` freshness is checked for read-only commands and repaired by `init`/`sync`.
+- **Schema validation**: Orders are validated through the Nickel `| Order` contract when present, then through Rust deserialization, `resolve_defaults()`, and Source path checks. Generated `order.contract.ncl` and `metadata.ncl` freshness is checked for read-only commands and repaired by `init`/`sync`.
 
 ---
 

--- a/blend/README.md
+++ b/blend/README.md
@@ -28,9 +28,14 @@ src/
 ├── metadata.rs          OS/arch/hostname/desktop/user detection
 ├── output.rs            log helpers (info/warn/error/success)
 │
-├── commands.rs          re-exports cmd_sync / cmd_view / cmd_status / cmd_table
+├── commands.rs          re-exports command handlers
 ├── commands/
+│   ├── add.rs           import Target files/directories into Source orders
+│   ├── create.rs        scaffold empty Source orders
+│   ├── check.rs         validate Source order definitions
+│   ├── format.rs        format order.ncl files
 │   ├── helpers.rs       shared symlink + diff-aggregation helpers
+│   ├── init.rs          refresh generated contract + metadata files
 │   ├── sync.rs          bidirectional sync + per-key interactive flow
 │   ├── view.rs          render preview & diff
 │   ├── status.rs        order state table (parallel via rayon)
@@ -60,7 +65,7 @@ src/
     └── text.rs          line-based diffing for plaintext
 
 tests/
-├── sync_e2e.rs          end-to-end CLI tests (39 scenarios)
+├── sync_e2e.rs          end-to-end CLI tests
 └── fixtures/            .ncl + deployed-file fixtures
 ```
 

--- a/blend/src/cli.rs
+++ b/blend/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 use crate::sandbox::SandboxMode;
@@ -23,6 +23,8 @@ Inspect:
 
 Maintain:
   check   [read] Validate Source order definitions
+  create  [source] Create a new order
+  add     [source] Add a Target file or directory to an order
   format  [source] Format Source order files
   init    [source, target] Initialize or refresh Blend metadata and config
   sync    [source, target] Reconcile Source orders and Target files
@@ -131,6 +133,37 @@ pub enum MaintainCommands {
         orders: Vec<String>,
     },
 
+    /// [source] Create a new order
+    Create {
+        /// Order to create
+        order: String,
+    },
+
+    /// [source] Add a Target file or directory to an existing order
+    #[command(long_about = "\
+[source] Add a Target file or directory to an existing order
+
+Copies the Target path into the order Source tree and appends a file entry to order.ncl.")]
+    Add {
+        /// Order to add the Target path to
+        order: String,
+
+        /// Target file or directory to add; must be absolute or start with ~
+        path: PathBuf,
+
+        /// Target prefix to strip before copying into the order Source tree
+        #[arg(long)]
+        prefix: Option<String>,
+
+        /// Symlink deployment policy; required when the Target path is a symlink
+        #[arg(long)]
+        symlink: Option<SymlinkMode>,
+
+        /// Allow overlapping Target paths with existing entries
+        #[arg(long)]
+        allow_overlap: bool,
+    },
+
     /// [source] Format Source order files
     #[command(alias = "fmt")]
     Format {
@@ -152,4 +185,12 @@ Writes or refreshes orders/order.contract.ncl and orders/metadata.ncl. For a new
         #[arg(long)]
         upgrade: bool,
     },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum SymlinkMode {
+    /// Copy resolved Target content into Source and deploy a real file/directory
+    Follow,
+    /// Copy resolved Target content into Source and deploy the Target as a symlink
+    Preserve,
 }

--- a/blend/src/commands.rs
+++ b/blend/src/commands.rs
@@ -1,4 +1,6 @@
+pub mod add;
 pub mod check;
+pub mod create;
 pub mod format;
 pub mod helpers;
 pub mod init;
@@ -7,7 +9,9 @@ pub mod sync;
 pub mod table;
 pub mod view;
 
+pub use add::cmd_add;
 pub use check::cmd_check;
+pub use create::cmd_create;
 pub use format::cmd_format;
 pub use init::cmd_init;
 pub use status::cmd_status;

--- a/blend/src/commands/add.rs
+++ b/blend/src/commands/add.rs
@@ -1,0 +1,643 @@
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context as AnyhowContext, bail};
+use similar::TextDiff;
+
+use crate::cli::SymlinkMode;
+use crate::commands::create::validate_order_name;
+use crate::compose::{build_order, discover_orders};
+use crate::context::Context;
+use crate::nickel::{
+    NickelEvaluator, Order, format_source, generated, normalize_order_source_path,
+};
+use crate::output::log;
+
+/// Add command: copy a Target file/directory into Source and append an entry.
+pub fn cmd_add(
+    ctx: &Context,
+    order: &str,
+    path: &Path,
+    prefix: Option<&str>,
+    symlink: Option<SymlinkMode>,
+    allow_overlap: bool,
+) -> anyhow::Result<()> {
+    generated::assert_orders_ready(&ctx.orders_dir)?;
+    validate_order_name(order)?;
+
+    let order_dir = ctx.orders_dir.join(order);
+    let order_path = order_dir.join("order.ncl");
+    if !order_path.exists() {
+        bail!("Order '{order}' not found. Run `blend create {order}` first.");
+    }
+
+    let target = expand_target_path(ctx, path)?;
+    let symlink_metadata = std::fs::symlink_metadata(&target)
+        .with_context(|| format!("Target path not found: {}", target.display()))?;
+    let is_target_symlink = symlink_metadata.file_type().is_symlink();
+    if is_target_symlink && symlink.is_none() {
+        bail!(
+            "{} is a symlink; pass --symlink follow or --symlink preserve",
+            target.display()
+        );
+    }
+
+    let metadata = std::fs::metadata(&target)
+        .with_context(|| format!("Failed to read Target metadata for {}", target.display()))?;
+    let target_is_dir = metadata.is_dir();
+    let deploy_as_symlink = symlink == Some(SymlinkMode::Preserve);
+
+    let raw_source = std::fs::read_to_string(&order_path)
+        .with_context(|| format!("Failed to read {}", order_path.display()))?;
+    let evaluator = NickelEvaluator::new(&ctx.metadata);
+    let order_data = evaluator.evaluate(&order_path)?;
+    let structure = OrderSourceStructure::parse(&raw_source)?;
+    let prefix_plan = choose_prefix(ctx, &order_data, &structure, &target, prefix)?;
+    let from_file = path_to_order_string(&prefix_plan.source_rel)?;
+    normalize_order_source_path(&from_file)?;
+
+    ensure_no_duplicate_entry(&order_data, &from_file)?;
+
+    let source_path = order_dir.join(&prefix_plan.source_rel);
+    if source_path.exists() {
+        bail!(
+            "Source path already exists in order: {}",
+            source_path.display()
+        );
+    }
+
+    detect_overlaps(ctx, &target, target_is_dir, allow_overlap)?;
+
+    let edited = edit_order_source(
+        &raw_source,
+        &structure,
+        &from_file,
+        deploy_as_symlink,
+        &prefix_plan,
+    )?;
+    let formatted = format_source(&edited)
+        .with_context(|| format!("Failed to format {}", order_path.display()))?;
+
+    if ctx.dry_run {
+        log::info(&format!(
+            "Dry run: would copy {} to {}",
+            target.display(),
+            source_path.display()
+        ));
+        print_source_diff(&raw_source, &formatted);
+        return Ok(());
+    }
+
+    copy_target_to_source(&target, &source_path, target_is_dir)?;
+    std::fs::write(&order_path, formatted)
+        .with_context(|| format!("Failed to write {}", order_path.display()))?;
+    evaluator.evaluate(&order_path)?;
+
+    log::success(&format!("Added {} to order '{order}'", target.display()));
+    Ok(())
+}
+
+struct PrefixPlan {
+    prefix_literal: String,
+    source_rel: PathBuf,
+    write_entry_prefix: bool,
+    promote_global_prefix: bool,
+}
+
+struct OrderSourceStructure {
+    blend_open: usize,
+    blend_close: usize,
+    files_close: Option<usize>,
+    has_prefix_field: bool,
+}
+
+impl OrderSourceStructure {
+    fn parse(source: &str) -> anyhow::Result<Self> {
+        let blend_value = find_field_value(source, "blend", 0, source.len())
+            .context("Could not find `blend` record in order.ncl")?;
+        let blend_open = skip_ws(source, blend_value);
+        if source.as_bytes().get(blend_open) != Some(&b'{') {
+            bail!("`blend` must be a record literal");
+        }
+        let blend_close = find_matching(source, blend_open, b'{', b'}')?;
+        let has_prefix_field =
+            find_field_value(source, "prefix", blend_open + 1, blend_close).is_some();
+        let files_close = if let Some(files_value) =
+            find_field_value(source, "files", blend_open + 1, blend_close)
+        {
+            let files_open = skip_ws(source, files_value);
+            if source.as_bytes().get(files_open) != Some(&b'[') {
+                bail!("`blend.files` must be an array literal");
+            }
+            Some(find_matching(source, files_open, b'[', b']')?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            blend_open,
+            blend_close,
+            files_close,
+            has_prefix_field,
+        })
+    }
+}
+
+fn choose_prefix(
+    ctx: &Context,
+    order: &Order,
+    structure: &OrderSourceStructure,
+    target: &Path,
+    prefix: Option<&str>,
+) -> anyhow::Result<PrefixPlan> {
+    let is_fresh_order = order.blend.files.is_empty()
+        && order.blend.prefix.is_empty()
+        && !structure.has_prefix_field;
+
+    if let Some(prefix) = prefix {
+        let expanded = ctx.expand_path_str(prefix);
+        let source_rel = strip_target_prefix(target, &expanded, prefix)?;
+        return Ok(PrefixPlan {
+            prefix_literal: prefix.to_string(),
+            source_rel,
+            write_entry_prefix: !is_fresh_order,
+            promote_global_prefix: is_fresh_order,
+        });
+    }
+
+    for existing_prefix in order.global_prefix() {
+        let expanded = ctx.expand_path_str(existing_prefix);
+        if let Ok(source_rel) = strip_target_prefix(target, &expanded, existing_prefix) {
+            return Ok(PrefixPlan {
+                prefix_literal: existing_prefix.clone(),
+                source_rel,
+                write_entry_prefix: false,
+                promote_global_prefix: false,
+            });
+        }
+    }
+
+    if !order.global_prefix().is_empty() {
+        bail!(
+            "{} is not under the order prefix. Pass --prefix to choose a Target prefix explicitly.",
+            target.display()
+        );
+    }
+
+    let prefix_literal = "~".to_string();
+    let expanded = ctx.expand_path_str(&prefix_literal);
+    let source_rel = strip_target_prefix(target, &expanded, &prefix_literal)?;
+    let promote_global_prefix = order.blend.files.is_empty() && !structure.has_prefix_field;
+
+    Ok(PrefixPlan {
+        prefix_literal,
+        source_rel,
+        write_entry_prefix: !promote_global_prefix,
+        promote_global_prefix,
+    })
+}
+
+fn expand_target_path(ctx: &Context, path: &Path) -> anyhow::Result<PathBuf> {
+    let raw = path.to_string_lossy();
+    if raw == "~" || raw.starts_with("~/") {
+        return Ok(ctx.expand_path(path));
+    }
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    bail!("Target path must be absolute or start with ~");
+}
+
+fn strip_target_prefix(
+    target: &Path,
+    prefix: &Path,
+    prefix_literal: &str,
+) -> anyhow::Result<PathBuf> {
+    let rel = target.strip_prefix(prefix).with_context(|| {
+        format!(
+            "{} is not under prefix {}",
+            target.display(),
+            prefix_literal
+        )
+    })?;
+    validate_relative_path(rel)?;
+    Ok(rel.to_path_buf())
+}
+
+fn validate_relative_path(path: &Path) -> anyhow::Result<()> {
+    let mut saw_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => saw_component = true,
+            Component::CurDir => {}
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                bail!("Target path resolves outside the selected prefix");
+            }
+        }
+    }
+    if !saw_component {
+        bail!("Target path must name a file or directory below the selected prefix");
+    }
+    Ok(())
+}
+
+fn path_to_order_string(path: &Path) -> anyhow::Result<String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(
+                part.to_str()
+                    .with_context(|| format!("Path is not valid UTF-8: {}", path.display()))?,
+            ),
+            Component::CurDir => {}
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                bail!("Source path escapes the order directory");
+            }
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+fn ensure_no_duplicate_entry(order: &Order, from_file: &str) -> anyhow::Result<()> {
+    let mut conflicts = Vec::new();
+    for entry in &order.blend.files {
+        if entry.from_file.as_deref() == Some(from_file) || entry.name == from_file {
+            conflicts.push(entry.name.clone());
+        }
+    }
+
+    if conflicts.is_empty() {
+        Ok(())
+    } else {
+        conflicts.sort();
+        bail!("Entry already exists in order: {}", conflicts.join(", "));
+    }
+}
+
+fn detect_overlaps(
+    ctx: &Context,
+    new_target: &Path,
+    new_is_dir: bool,
+    allow_overlap: bool,
+) -> anyhow::Result<()> {
+    let mut conflicts = Vec::new();
+    let mut orders: Vec<_> = discover_orders(&ctx.orders_dir).into_iter().collect();
+    orders.sort();
+
+    for order in orders {
+        match build_order(ctx, &order) {
+            Ok(results) => {
+                for result in results {
+                    let existing_is_dir = result
+                        .source_path
+                        .as_ref()
+                        .is_some_and(|source| source.is_dir());
+                    if paths_overlap(new_target, new_is_dir, &result.target, existing_is_dir) {
+                        conflicts.push(format!(
+                            "{}:{} -> {}",
+                            order,
+                            result.name,
+                            result.target.display()
+                        ));
+                    }
+                }
+            }
+            Err(err) if allow_overlap => {
+                log::warn(&format!("Skipping overlap check for {order}: {err:#}"));
+            }
+            Err(err) => {
+                bail!("Failed to check overlaps for {order}: {err:#}");
+            }
+        }
+    }
+
+    if conflicts.is_empty() {
+        return Ok(());
+    }
+
+    conflicts.sort();
+    if allow_overlap {
+        log::warn(&format!(
+            "Target path overlaps existing entries: {}",
+            conflicts.join("; ")
+        ));
+        Ok(())
+    } else {
+        bail!(
+            "Target path overlaps existing entries: {}. Pass --allow-overlap to continue.",
+            conflicts.join("; ")
+        );
+    }
+}
+
+fn paths_overlap(
+    new_path: &Path,
+    new_is_dir: bool,
+    existing_path: &Path,
+    existing_is_dir: bool,
+) -> bool {
+    new_path == existing_path
+        || (new_is_dir && existing_path.starts_with(new_path))
+        || (existing_is_dir && new_path.starts_with(existing_path))
+}
+
+fn copy_target_to_source(target: &Path, source: &Path, is_dir: bool) -> anyhow::Result<()> {
+    if let Some(parent) = source.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    if is_dir {
+        copy_dir_recursive(target, source)
+    } else {
+        std::fs::copy(target, source).with_context(|| {
+            format!(
+                "Failed to copy {} to {}",
+                target.display(),
+                source.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("Failed to create {}", dst.display()))?;
+    for entry in
+        std::fs::read_dir(src).with_context(|| format!("Failed to read {}", src.display()))?
+    {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        // Directory imports follow interior symlinks. The explicit symlink
+        // policy only applies to the top-level Target path passed to add.
+        let metadata = std::fs::metadata(&src_path)
+            .with_context(|| format!("Failed to read metadata for {}", src_path.display()))?;
+        if metadata.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path).with_context(|| {
+                format!(
+                    "Failed to copy {} to {}",
+                    src_path.display(),
+                    dst_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn edit_order_source(
+    source: &str,
+    structure: &OrderSourceStructure,
+    from_file: &str,
+    deploy_as_symlink: bool,
+    prefix_plan: &PrefixPlan,
+) -> anyhow::Result<String> {
+    let mut result = source.to_string();
+    if let Some(files_close) = structure.files_close {
+        let mut insertion = String::new();
+        if !array_has_trailing_comma(source, files_close) {
+            insertion.push(',');
+        }
+        insertion.push('\n');
+        insertion.push_str(&entry_ncl(from_file, deploy_as_symlink, prefix_plan, 6));
+        result.insert_str(files_close, &insertion);
+
+        if prefix_plan.promote_global_prefix {
+            insert_global_prefix_at_start(&mut result, structure, prefix_plan);
+        }
+        return Ok(result);
+    }
+
+    let fields = format!(
+        "\n    files = [\n{}\n    ],",
+        entry_ncl(from_file, deploy_as_symlink, prefix_plan, 6)
+    );
+
+    let mut insertion = String::new();
+    if !record_has_trailing_comma(source, structure.blend_close) {
+        insertion.push(',');
+    }
+    insertion.push_str(&fields);
+    result.insert_str(structure.blend_close, &insertion);
+
+    if prefix_plan.promote_global_prefix {
+        insert_global_prefix_at_start(&mut result, structure, prefix_plan);
+    }
+    Ok(result)
+}
+
+fn insert_global_prefix_at_start(
+    source: &mut String,
+    structure: &OrderSourceStructure,
+    prefix_plan: &PrefixPlan,
+) {
+    let prefix_text = format!(
+        "\n    prefix = [{}],",
+        nickel_string(&prefix_plan.prefix_literal)
+    );
+    source.insert_str(structure.blend_open + 1, &prefix_text);
+}
+
+fn entry_ncl(
+    from_file: &str,
+    deploy_as_symlink: bool,
+    prefix_plan: &PrefixPlan,
+    indent: usize,
+) -> String {
+    let pad = " ".repeat(indent);
+    let field_pad = " ".repeat(indent + 2);
+    let mut entry = format!(
+        "{pad}{{\n{field_pad}from_file = {},",
+        nickel_string(from_file)
+    );
+    if deploy_as_symlink {
+        entry.push_str(&format!("\n{field_pad}symlink = true,"));
+    }
+    if prefix_plan.write_entry_prefix {
+        entry.push_str(&format!(
+            "\n{field_pad}prefix = [{}],",
+            nickel_string(&prefix_plan.prefix_literal)
+        ));
+    }
+    entry.push_str(&format!("\n{pad}}},"));
+    entry
+}
+
+fn nickel_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a string cannot fail")
+}
+
+fn print_source_diff(old: &str, new: &str) {
+    let diff = TextDiff::from_lines(old, new);
+    for hunk in diff.unified_diff().context_radius(3).iter_hunks() {
+        print!("{}", hunk.header());
+        for change in hunk.iter_changes() {
+            print!("{}{}", change.tag(), change);
+        }
+    }
+}
+
+fn array_has_trailing_comma(source: &str, close: usize) -> bool {
+    previous_non_ws_code_byte(source, close).is_none_or(|byte| byte == b'[' || byte == b',')
+}
+
+fn record_has_trailing_comma(source: &str, close: usize) -> bool {
+    previous_non_ws_code_byte(source, close).is_none_or(|byte| byte == b'{' || byte == b',')
+}
+
+fn previous_non_ws_code_byte(source: &str, offset: usize) -> Option<u8> {
+    let mut previous = None;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut in_comment = false;
+
+    for byte in source.as_bytes()[..offset].iter().copied() {
+        if in_comment {
+            if byte == b'\n' {
+                in_comment = false;
+            }
+            continue;
+        }
+
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+                previous = Some(byte);
+            }
+            continue;
+        }
+
+        match byte {
+            b'#' => in_comment = true,
+            b'"' => in_string = true,
+            byte if byte.is_ascii_whitespace() => {}
+            byte => previous = Some(byte),
+        }
+    }
+
+    previous
+}
+
+fn skip_ws(source: &str, mut offset: usize) -> usize {
+    while source
+        .as_bytes()
+        .get(offset)
+        .is_some_and(|b| b.is_ascii_whitespace())
+    {
+        offset += 1;
+    }
+    offset
+}
+
+fn find_field_value(source: &str, field: &str, start: usize, end: usize) -> Option<usize> {
+    let mut scanner = Scanner::new(source, start, end);
+    while let Some(pos) = scanner.next_code_byte() {
+        if !source[pos..].starts_with(field) || !is_field_boundary(source, pos, field.len()) {
+            continue;
+        }
+        let after = skip_ws(source, pos + field.len());
+        if source.as_bytes().get(after) != Some(&b'=') {
+            continue;
+        }
+        return Some(after + 1);
+    }
+    None
+}
+
+fn is_field_boundary(source: &str, pos: usize, len: usize) -> bool {
+    let before_ok = pos == 0
+        || !source.as_bytes()[pos - 1].is_ascii_alphanumeric()
+            && source.as_bytes()[pos - 1] != b'_';
+    let after = pos + len;
+    let after_ok = after >= source.len()
+        || !source.as_bytes()[after].is_ascii_alphanumeric() && source.as_bytes()[after] != b'_';
+    before_ok && after_ok
+}
+
+fn find_matching(source: &str, open: usize, open_ch: u8, close_ch: u8) -> anyhow::Result<usize> {
+    let mut scanner = Scanner::new(source, open, source.len());
+    let mut depth = 0usize;
+    while let Some(pos) = scanner.next_code_byte() {
+        match source.as_bytes()[pos] {
+            ch if ch == open_ch => depth += 1,
+            ch if ch == close_ch => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(pos);
+                }
+            }
+            _ => {}
+        }
+    }
+    bail!("Could not find matching delimiter in order.ncl");
+}
+
+struct Scanner<'a> {
+    source: &'a str,
+    offset: usize,
+    end: usize,
+    in_string: bool,
+    escaped: bool,
+    in_comment: bool,
+}
+
+impl<'a> Scanner<'a> {
+    // This lightweight scanner is only for preserving common order.ncl shapes.
+    // It skips quoted strings and line comments, but does not model Nickel's
+    // multiline strings or interpolation expressions.
+    fn new(source: &'a str, start: usize, end: usize) -> Self {
+        Self {
+            source,
+            offset: start,
+            end,
+            in_string: false,
+            escaped: false,
+            in_comment: false,
+        }
+    }
+
+    fn next_code_byte(&mut self) -> Option<usize> {
+        while self.offset < self.end {
+            let pos = self.offset;
+            let byte = self.source.as_bytes()[pos];
+            self.offset += 1;
+
+            if self.in_comment {
+                if byte == b'\n' {
+                    self.in_comment = false;
+                }
+                continue;
+            }
+
+            if self.in_string {
+                if self.escaped {
+                    self.escaped = false;
+                } else if byte == b'\\' {
+                    self.escaped = true;
+                } else if byte == b'"' {
+                    self.in_string = false;
+                }
+                continue;
+            }
+
+            match byte {
+                b'#' => {
+                    self.in_comment = true;
+                    continue;
+                }
+                b'"' => {
+                    self.in_string = true;
+                    continue;
+                }
+                _ => return Some(pos),
+            }
+        }
+        None
+    }
+}

--- a/blend/src/commands/create.rs
+++ b/blend/src/commands/create.rs
@@ -1,0 +1,55 @@
+use anyhow::{Context as AnyhowContext, bail};
+
+use crate::context::Context;
+use crate::nickel::{format_source, generated};
+use crate::output::log;
+
+/// Create command: scaffold a new empty order under orders/<order>.
+pub fn cmd_create(ctx: &Context, order: &str) -> anyhow::Result<()> {
+    generated::assert_orders_ready(&ctx.orders_dir)?;
+    validate_order_name(order)?;
+
+    let order_dir = ctx.orders_dir.join(order);
+    let order_path = order_dir.join("order.ncl");
+    if order_dir.exists() || order_path.exists() {
+        bail!("Order '{order}' already exists");
+    }
+
+    let source = format_source(&starter_ncl())?;
+
+    if ctx.dry_run {
+        log::info(&format!("Dry run: would create {}", order_path.display()));
+        println!("{source}");
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&order_dir)
+        .with_context(|| format!("Failed to create {}", order_dir.display()))?;
+    std::fs::write(&order_path, source)
+        .with_context(|| format!("Failed to write {}", order_path.display()))?;
+    log::success(&format!("Created order '{order}'"));
+    Ok(())
+}
+
+pub fn validate_order_name(order: &str) -> anyhow::Result<()> {
+    if order.is_empty()
+        || order == "."
+        || order == ".."
+        || order.contains('/')
+        || order.contains('\\')
+    {
+        bail!("Invalid order name '{order}'");
+    }
+    Ok(())
+}
+
+fn starter_ncl() -> String {
+    r#"let { Order, .. } = import "../order.contract.ncl" in
+{
+  blend = {
+    files = [],
+  },
+} | Order
+"#
+    .to_string()
+}

--- a/blend/src/context.rs
+++ b/blend/src/context.rs
@@ -139,6 +139,8 @@ fn command_can_update_blend_dir_state(cli: &Cli) -> bool {
     matches!(
         cli.command,
         Some(Commands::Maintain(MaintainCommands::Sync { .. }))
+            | Some(Commands::Maintain(MaintainCommands::Create { .. }))
+            | Some(Commands::Maintain(MaintainCommands::Add { .. }))
             | Some(Commands::Maintain(MaintainCommands::Format { .. }))
             | Some(Commands::Maintain(MaintainCommands::Init { .. }))
     )

--- a/blend/src/main.rs
+++ b/blend/src/main.rs
@@ -16,7 +16,9 @@ mod sync;
 use clap::Parser;
 
 use cli::{Cli, Commands, InspectCommands, MaintainCommands};
-use commands::{cmd_check, cmd_format, cmd_init, cmd_status, cmd_sync, cmd_table, cmd_view};
+use commands::{
+    cmd_add, cmd_check, cmd_create, cmd_format, cmd_init, cmd_status, cmd_sync, cmd_table, cmd_view,
+};
 use context::{Context, sandbox_mode_from_cli_and_config};
 use output::log;
 use sandbox::SandboxMode;
@@ -106,6 +108,21 @@ fn main() {
             short,
         })) => cmd_view(&ctx, &orders, content_only, all, short),
         Some(Commands::Maintain(MaintainCommands::Check { orders })) => cmd_check(&ctx, &orders),
+        Some(Commands::Maintain(MaintainCommands::Create { order })) => cmd_create(&ctx, &order),
+        Some(Commands::Maintain(MaintainCommands::Add {
+            order,
+            path,
+            prefix,
+            symlink,
+            allow_overlap,
+        })) => cmd_add(
+            &ctx,
+            &order,
+            &path,
+            prefix.as_deref(),
+            symlink,
+            allow_overlap,
+        ),
         Some(Commands::Maintain(MaintainCommands::Format { orders, check })) => {
             cmd_format(&ctx, &orders, check)
         }

--- a/blend/src/nickel.rs
+++ b/blend/src/nickel.rs
@@ -4,5 +4,5 @@ mod loader;
 mod schema;
 pub mod structure_map;
 
-pub use loader::{NickelEvaluator, format_source};
+pub use loader::{NickelEvaluator, format_source, normalize_order_source_path};
 pub use schema::{FileEntry, Format, Order};

--- a/blend/src/nickel/generated.rs
+++ b/blend/src/nickel/generated.rs
@@ -407,6 +407,7 @@ mod tests {
 let { Order, .. } = import "../order.contract.ncl" in
 {
   blend = {
+    prefix = ["~/.config/schema-agreement/"],
     files = [
       {
         name = "agreement.toml",

--- a/blend/src/nickel/loader.rs
+++ b/blend/src/nickel/loader.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context as AnyhowContext, Result};
 use nickel_lang::Context;
@@ -62,6 +62,8 @@ impl NickelEvaluator {
                 .with_context(|| format!("Invalid file entry in {}", ncl_path.display()))?;
         }
 
+        validate_order_source_paths(&order, ncl_path)?;
+
         if timing {
             eprintln!(
                 "[timing] eval {}: total={}us nickel={}us",
@@ -113,6 +115,60 @@ impl NickelEvaluator {
 
         Ok(json)
     }
+}
+
+fn validate_order_source_paths(order: &Order, ncl_path: &Path) -> Result<()> {
+    for entry in &order.blend.files {
+        if let Some(from_file) = &entry.from_file {
+            normalize_order_source_path(from_file).with_context(|| {
+                format!("Invalid from_file '{from_file}' in {}", ncl_path.display())
+            })?;
+        }
+
+        if let Some(local) = &entry.local {
+            normalize_order_source_path(local)
+                .with_context(|| format!("Invalid local '{local}' in {}", ncl_path.display()))?;
+        }
+
+        if entry.prefix.is_empty() && order.blend.prefix.is_empty() {
+            anyhow::bail!(
+                "Invalid file entry '{}' in {}: no effective prefix; set blend.prefix or entry.prefix",
+                entry.name,
+                ncl_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn normalize_order_source_path(path: &str) -> Result<PathBuf> {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        anyhow::bail!("source paths must be relative to the order directory");
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => normalized.push(part),
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    anyhow::bail!("source path escapes the order directory");
+                }
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                anyhow::bail!("source paths must be relative to the order directory");
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        anyhow::bail!("source path cannot be empty");
+    }
+
+    Ok(normalized)
 }
 
 #[cfg(test)]

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -82,13 +82,21 @@ fn copy_fixture(order_name: &str) -> TempDir {
     let order_dst = orders_dst.join(order_name);
     copy_dir_recursive(&order_src, &order_dst);
 
+    copy_shared_order_files(temp.path());
+
+    temp
+}
+
+fn copy_shared_order_files(blend_dir: &Path) {
+    let orders_src = fixtures_dir().join("orders");
+    let orders_dst = orders_dir(blend_dir);
+    std::fs::create_dir_all(&orders_dst).unwrap();
+
     // Copy the two blend-owned schema files so reader commands don't fail
     // their freshness check and so metadata-importing fixtures resolve.
     for shared in ["order.contract.ncl", "metadata.ncl"] {
         std::fs::copy(orders_src.join(shared), orders_dst.join(shared)).unwrap();
     }
-
-    temp
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) {
@@ -102,6 +110,239 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
             std::fs::copy(entry.path(), &target).unwrap();
         }
     }
+}
+
+#[test]
+fn test_create_order_scaffolds_empty_order() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+
+    let output = run_blend(home.path(), blend_dir.path(), &["create", "kitty"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend create failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("Created order 'kitty'"));
+
+    let order_path = orders_dir(blend_dir.path()).join("kitty/order.ncl");
+    let source = std::fs::read_to_string(&order_path).unwrap();
+    assert!(source.contains("files = []"));
+
+    let check = run_blend(home.path(), blend_dir.path(), &["check", "kitty"]);
+    assert!(
+        check.status.success(),
+        "created order should check:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+#[test]
+fn test_add_target_path_defaults_to_home_prefix() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+    run_blend(home.path(), blend_dir.path(), &["create", "kitty"]);
+
+    let target = home.path().join(".config/kitty/kitty.conf");
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::fs::write(&target, "font_size 13\n").unwrap();
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["add", "kitty", "~/.config/kitty/kitty.conf"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend add failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("Added"));
+
+    let copied = orders_dir(blend_dir.path()).join("kitty/.config/kitty/kitty.conf");
+    assert_eq!(std::fs::read_to_string(copied).unwrap(), "font_size 13\n");
+
+    let order_source =
+        std::fs::read_to_string(orders_dir(blend_dir.path()).join("kitty/order.ncl")).unwrap();
+    assert!(order_source.contains(r#"prefix = ["~"]"#));
+    assert!(order_source.contains(r#"from_file = ".config/kitty/kitty.conf""#));
+    assert!(
+        order_source.find("prefix =").unwrap() < order_source.find("files =").unwrap(),
+        "promoted order prefix should be inserted before files:\n{order_source}"
+    );
+
+    let check = run_blend(home.path(), blend_dir.path(), &["check", "kitty"]);
+    assert!(
+        check.status.success(),
+        "added order should check:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+}
+
+#[test]
+fn test_add_target_path_with_explicit_prefix_strips_prefix() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+    run_blend(home.path(), blend_dir.path(), &["create", "kitty"]);
+
+    let target = home.path().join(".config/kitty/kitty.conf");
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::fs::write(&target, "font_size 13\n").unwrap();
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &[
+            "add",
+            "kitty",
+            "--prefix",
+            "~/.config/kitty",
+            "~/.config/kitty/kitty.conf",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend add --prefix failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let copied = orders_dir(blend_dir.path()).join("kitty/kitty.conf");
+    assert_eq!(std::fs::read_to_string(copied).unwrap(), "font_size 13\n");
+
+    let order_source =
+        std::fs::read_to_string(orders_dir(blend_dir.path()).join("kitty/order.ncl")).unwrap();
+    assert!(order_source.contains(r#"prefix = ["~/.config/kitty"]"#));
+    assert!(order_source.contains(r#"from_file = "kitty.conf""#));
+    assert!(
+        order_source.find("prefix =").unwrap() < order_source.find("files =").unwrap(),
+        "promoted order prefix should be inserted before files:\n{order_source}"
+    );
+}
+
+#[test]
+fn test_add_promoted_prefix_goes_before_comments_when_files_is_absent() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+
+    let order_dir = orders_dir(blend_dir.path()).join("kitty");
+    std::fs::create_dir_all(&order_dir).unwrap();
+    std::fs::write(
+        order_dir.join("order.ncl"),
+        r#"let { Order, .. } = import "../order.contract.ncl" in
+{
+  blend = {
+    # no files yet
+  },
+} | Order
+"#,
+    )
+    .unwrap();
+
+    let target = home.path().join(".config/kitty/kitty.conf");
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::fs::write(&target, "font_size 13\n").unwrap();
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["add", "kitty", "~/.config/kitty/kitty.conf"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blend add failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let order_source =
+        std::fs::read_to_string(orders_dir(blend_dir.path()).join("kitty/order.ncl")).unwrap();
+    let prefix_pos = order_source.find("prefix =").unwrap();
+    assert!(
+        prefix_pos < order_source.find("# no files yet").unwrap(),
+        "promoted order prefix should be inserted before existing comments:\n{order_source}"
+    );
+    assert!(
+        prefix_pos < order_source.find("files =").unwrap(),
+        "promoted order prefix should be inserted before created files:\n{order_source}"
+    );
+}
+
+#[test]
+fn test_add_symlink_target_requires_explicit_policy() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+    run_blend(home.path(), blend_dir.path(), &["create", "kitty"]);
+
+    let real = home.path().join(".config/kitty/real.conf");
+    let link = home.path().join(".config/kitty/kitty.conf");
+    std::fs::create_dir_all(real.parent().unwrap()).unwrap();
+    std::fs::write(&real, "font_size 13\n").unwrap();
+    create_symlink(&real, &link);
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["add", "kitty", "~/.config/kitty/kitty.conf"],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "blend add should reject symlink without policy"
+    );
+    assert!(stderr.contains("--symlink follow") && stderr.contains("--symlink preserve"));
+}
+
+#[test]
+fn test_check_rejects_from_file_that_escapes_order_dir() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+
+    let order_dir = orders_dir(blend_dir.path()).join("bad");
+    std::fs::create_dir_all(&order_dir).unwrap();
+    std::fs::write(
+        order_dir.join("order.ncl"),
+        r#"let { Order, .. } = import "../order.contract.ncl" in
+{
+  blend = {
+    prefix = ["~"],
+    files = [
+      {
+        from_file = "../outside",
+      },
+    ],
+  },
+} | Order
+"#,
+    )
+    .unwrap();
+
+    let output = run_blend(home.path(), blend_dir.path(), &["check", "bad"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "blend check should reject escaping from_file"
+    );
+    assert!(
+        stderr.contains("source path escapes the order directory"),
+        "stderr should explain escaping path:\n{stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `blend create <order>` to scaffold empty Source orders
- add `blend add <order> <target>` with prefix stripping, symlink policy, overlap checks, dry-run diffing, and top-level prefix promotion
- tighten order source paths so `from_file` / `local` cannot escape the order directory and file entries require an effective prefix
- refresh project docs for the new create/add commands, stricter Source path rules, and current bin/command layout

Closes #35.

## Breaking Change
- Blend now rejects order `from_file` and `local` paths that are absolute or normalize outside the order directory.
- File entries now require an effective prefix from either `blend.prefix` or entry-level `prefix`.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo run -- check`
- `cargo run -- format --check`
- `git -c core.fsmonitor=false diff --check`
- `bin/blend check`
- `bin/blend format --check`