### PR TITLE
fix(blend): stabilize tests and remove stale code

### DIFF
--- a/blend/src/commands/helpers.rs
+++ b/blend/src/commands/helpers.rs
@@ -17,7 +17,7 @@ pub fn select_orders(ctx: &Context, orders: &[String]) -> Vec<String> {
 
 /// For directory-style entries: walk the source dir and check whether any
 /// per-file target is itself a symlink. Returns true even when resolved
-/// content matches, so callers can flag legacy stow leftovers within an
+/// content matches, so callers can flag unexpected symlinks within an
 /// otherwise in-sync directory.
 pub fn dir_has_inner_symlinks(source_dir: &std::path::Path, target_dir: &std::path::Path) -> bool {
     diff_directory(source_dir, target_dir, &[])

--- a/blend/src/commands/status.rs
+++ b/blend/src/commands/status.rs
@@ -157,7 +157,7 @@ pub fn cmd_status(ctx: &Context) -> anyhow::Result<()> {
                                     )
                                 }
                             } else if target.exists() || target.symlink_metadata().is_ok() {
-                                // Check for unexpected symlink (stow leftover).
+                                // Check for an unexpected target symlink.
                                 // For directory entries, also walk the source dir
                                 // and detect per-file symlinks within the target,
                                 // since the directory itself can be a real dir

--- a/blend/src/compose.rs
+++ b/blend/src/compose.rs
@@ -236,7 +236,7 @@ fn build_file_entry(
 ///
 /// Walks up from the target path to find any path component that is a symlink
 /// (broken or otherwise) and removes it before calling `create_dir_all`.
-/// This handles the case where old stow/symlink deployments left behind symlinks
+/// This handles the case where previous deployments left behind symlinks
 /// at directories that blend now needs to create as real directories.
 fn ensure_dir(path: &Path) -> Result<()> {
     for ancestor in path.ancestors() {

--- a/blend/src/context.rs
+++ b/blend/src/context.rs
@@ -25,7 +25,10 @@ impl Context {
     pub fn new(cli: &Cli) -> Result<Self> {
         let home_dir = home_dir_from_cli(cli);
         let state = StateStore::from_env_for_home(&home_dir);
+        Self::new_with_home_and_state(cli, home_dir, state)
+    }
 
+    fn new_with_home_and_state(cli: &Cli, home_dir: PathBuf, state: StateStore) -> Result<Self> {
         let blend_dir_choice = resolve_blend_dir(cli, &state)?;
         let blend_dir = blend_dir_choice.path;
         let orders_dir = blend_dir.join("orders");
@@ -228,12 +231,9 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn context_carries_a_state_store_resolved_from_env() {
+    fn context_carries_an_explicit_state_store() {
         let tmp = TempDir::new().unwrap();
-        let xdg = TempDir::new().unwrap();
-        // SAFETY: serial test setup; restore via guard after.
-        let prev_xdg = std::env::var_os("XDG_STATE_HOME");
-        unsafe { std::env::set_var("XDG_STATE_HOME", xdg.path()) };
+        let state_home = TempDir::new().unwrap();
 
         let cli = Cli::parse_from([
             "blend",
@@ -242,7 +242,8 @@ mod tests {
             "--home",
             tmp.path().to_str().unwrap(),
         ]);
-        let ctx = Context::new(&cli).unwrap();
+        let state = StateStore::with_root(state_home.path().join("blend/snapshots"));
+        let ctx = Context::new_with_home_and_state(&cli, tmp.path().to_path_buf(), state).unwrap();
         assert_eq!(ctx.blend_dir, tmp.path());
         assert_eq!(ctx.orders_dir, tmp.path().join("orders"));
 
@@ -252,21 +253,14 @@ mod tests {
         let got = ctx.state.read("order_name", &target).unwrap().unwrap();
         assert_eq!(got, b"hello");
 
-        // Snapshot should land under the XDG override, not the user's real state dir.
+        // Snapshot should land under the explicit state root.
         let p = ctx.state.snapshot_path("order_name", &target).unwrap();
         assert!(
-            p.starts_with(xdg.path()),
+            p.starts_with(state_home.path()),
             "expected snapshot under {} but got {}",
-            xdg.path().display(),
+            state_home.path().display(),
             p.display()
         );
-
-        unsafe {
-            match prev_xdg {
-                Some(v) => std::env::set_var("XDG_STATE_HOME", v),
-                None => std::env::remove_var("XDG_STATE_HOME"),
-            }
-        }
     }
 
     #[test]

--- a/blend/src/diff.rs
+++ b/blend/src/diff.rs
@@ -1,7 +1,6 @@
 mod semantic;
 mod text;
 
-#[allow(unused_imports)]
 pub use semantic::{
     KeyChange, KeyChangeType, key_change_with_base_display, semantic_diff, semantic_diff_keys,
     semantic_diff_with_base,
@@ -52,7 +51,7 @@ pub struct FileDiffResult {
     /// Whether the file only exists in the source (not yet deployed)
     pub source_only: bool,
     /// Whether the deployed target is a symlink. Set even when resolved
-    /// content matches the source, so callers can flag legacy stow leftovers
+    /// content matches the source, so callers can flag unexpected symlinks
     /// that need to be replaced with a real file on the next sync.
     pub target_is_symlink: bool,
 }
@@ -407,7 +406,7 @@ mod tests {
         assert!(results[0].source_only);
     }
 
-    /// Legacy stow leftover: target file is a symlink whose resolved content
+    /// Unexpected target symlink whose resolved content
     /// matches the source. Even though contents agree, the deployed file's
     /// type is wrong and a redeploy is required.
     #[cfg(unix)]

--- a/blend/src/diff/semantic.rs
+++ b/blend/src/diff/semantic.rs
@@ -21,7 +21,6 @@ pub enum KeyChangeType {
 
 /// A single key-level change between Source and Target configs
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct KeyChange {
     /// Structured key path; each segment is one literal key (segments may
     /// contain dots or brackets). `Display` joins with '.' for UI only.

--- a/blend/src/diff/text.rs
+++ b/blend/src/diff/text.rs
@@ -167,45 +167,6 @@ fn base_line_at<'a>(base_lines: &'a [&str], index: Option<usize>) -> &'a str {
         .trim_end()
 }
 
-/// Create a compact diff showing only changed lines with context
-#[allow(dead_code)]
-pub fn compact_diff(generated: &str, deployed: &str, context_lines: usize) -> DiffResult {
-    if generated == deployed {
-        return DiffResult::no_changes();
-    }
-
-    let diff = TextDiff::from_lines(deployed, generated);
-    let mut output = Vec::new();
-
-    for hunk in diff
-        .unified_diff()
-        .context_radius(context_lines)
-        .iter_hunks()
-    {
-        output.push(format!("{}", style(hunk.header().to_string()).dim()));
-        for change in hunk.iter_changes() {
-            let line = change.value().trim_end();
-            match change.tag() {
-                ChangeTag::Delete => {
-                    output.push(format!("{}", style(format!(">> Target: {line}")).magenta()));
-                }
-                ChangeTag::Insert => {
-                    output.push(format!("{}", style(format!("<< Source: {line}")).blue()));
-                }
-                ChangeTag::Equal => {
-                    output.push(format!(" {}", line));
-                }
-            }
-        }
-    }
-
-    if output.is_empty() {
-        DiffResult::no_changes()
-    } else {
-        DiffResult::with_changes(output.join("\n"))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,15 +203,5 @@ mod tests {
         let ignore = vec!["^tree_view".to_string(), "^color_scheme".to_string()];
         let result = text_diff(generated, deployed, &ignore);
         assert!(!result.has_changes);
-    }
-
-    #[test]
-    fn test_compact_diff() {
-        let old = "line1\nline2\nline3\nline4\nline5";
-        let new = "line1\nmodified\nline3\nline4\nline5";
-        let result = compact_diff(new, old, 1);
-        assert!(result.has_changes);
-        assert!(result.output.contains(">> Target: line2"));
-        assert!(result.output.contains("<< Source: modified"));
     }
 }

--- a/blend/src/nickel/ast_utils.rs
+++ b/blend/src/nickel/ast_utils.rs
@@ -22,7 +22,6 @@ use crate::nickel::key_path::KeyPath;
 // ---------------------------------------------------------------------------
 
 /// Result of analyzing a from_config value for rewritability
-#[allow(dead_code)]
 pub enum RewriteResult {
     /// All fields reach rewritable leaf values
     Rewritable { leaf_spans: Vec<LeafSpan> },
@@ -85,7 +84,6 @@ pub struct LeafSpan {
 }
 
 /// A field whose value cannot be auto-pulled
-#[allow(dead_code)]
 pub struct NonRewritableField {
     /// Dotted display name (for messages only; see `LeafSpan::name`)
     pub name: String,
@@ -93,8 +91,6 @@ pub struct NonRewritableField {
     pub path: KeyPath,
     /// Why it can't be rewritten
     pub reason: String,
-    /// Conditions followed before reaching the non-rewritable node
-    pub branch_context: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -122,7 +118,6 @@ fn find_rewritable_value<'ast>(
             } else {
                 SingleFieldResult::NotRewritable {
                     reason: "no source position".to_string(),
-                    branch_context: context.clone(),
                 }
             }
         }
@@ -140,13 +135,11 @@ fn find_rewritable_value<'ast>(
                 } else {
                     SingleFieldResult::NotRewritable {
                         reason: "no source position".to_string(),
-                        branch_context: context.clone(),
                     }
                 }
             } else {
                 SingleFieldResult::NotRewritable {
                     reason: "string with interpolation".to_string(),
-                    branch_context: context.clone(),
                 }
             }
         }
@@ -163,7 +156,6 @@ fn find_rewritable_value<'ast>(
             } else {
                 SingleFieldResult::NotRewritable {
                     reason: "no source position".to_string(),
-                    branch_context: context.clone(),
                 }
             }
         }
@@ -184,18 +176,15 @@ fn find_rewritable_value<'ast>(
                         }
                         SingleFieldResult::NotRewritable {
                             reason: format!("no match branch for value \"{}\"", resolved),
-                            branch_context: context.clone(),
                         }
                     } else {
                         SingleFieldResult::NotRewritable {
                             reason: "cannot resolve match argument against metadata".to_string(),
-                            branch_context: context.clone(),
                         }
                     }
                 } else {
                     SingleFieldResult::NotRewritable {
                         reason: "match applied without argument".to_string(),
-                        branch_context: context.clone(),
                     }
                 }
             } else {
@@ -218,7 +207,6 @@ fn find_rewritable_value<'ast>(
             } else {
                 SingleFieldResult::NotRewritable {
                     reason: "cannot evaluate if condition".to_string(),
-                    branch_context: context.clone(),
                 }
             }
         }
@@ -226,7 +214,6 @@ fn find_rewritable_value<'ast>(
         // Everything else: not rewritable
         _ => SingleFieldResult::NotRewritable {
             reason: "unsupported expression type".to_string(),
-            branch_context: context.clone(),
         },
     }
 }
@@ -240,7 +227,6 @@ enum SingleFieldResult {
     },
     NotRewritable {
         reason: String,
-        branch_context: Vec<String>,
     },
 }
 
@@ -572,15 +558,11 @@ fn collect_fields_from_record_with_prefix<'ast>(
                     branch_context,
                 });
             }
-            SingleFieldResult::NotRewritable {
-                reason,
-                branch_context,
-            } => {
+            SingleFieldResult::NotRewritable { reason } => {
                 non_rewritable.push(NonRewritableField {
                     name: full_name,
                     path: full_path,
                     reason,
-                    branch_context,
                 });
             }
         }
@@ -791,18 +773,6 @@ pub enum FieldEdit {
     Delete { path: KeyPath },
 }
 
-impl FieldEdit {
-    /// Consumed by tests today and by Stage 2's decision accounting.
-    #[allow(dead_code)]
-    pub fn path(&self) -> &KeyPath {
-        match self {
-            FieldEdit::Modify { path, .. }
-            | FieldEdit::Insert { path, .. }
-            | FieldEdit::Delete { path } => path,
-        }
-    }
-}
-
 /// Extended surgical rewrite that supports value modification, field insertion,
 /// and field deletion.
 ///
@@ -959,7 +929,12 @@ pub fn surgical_rewrite_with_structure(
                     .map(|pos| pos + 1) // skip the \n itself
                     .unwrap_or(field.full_range.start);
 
-                let delete_start = line_start;
+                let delete_start = leading_comment_block_start(
+                    source,
+                    &structure.comments,
+                    line_start,
+                    field.full_range.start,
+                );
                 let mut delete_end = field.full_range.end;
 
                 // Also consume trailing whitespace and newline after the field
@@ -996,6 +971,44 @@ pub fn surgical_rewrite_with_structure(
         applied,
         unapplied,
     })
+}
+
+/// Include a contiguous block of standalone comments immediately above a
+/// deleted field. Blank lines and inline comments form a boundary so comments
+/// belonging to the surrounding record or previous field are preserved.
+fn leading_comment_block_start(
+    source: &str,
+    comments: &[std::ops::Range<usize>],
+    field_line_start: usize,
+    field_start: usize,
+) -> usize {
+    let field_indent = &source[field_line_start..field_start];
+    let mut delete_start = field_line_start;
+
+    while let Some(comment) = comments
+        .iter()
+        .filter(|comment| comment.end <= delete_start)
+        .max_by_key(|comment| comment.end)
+    {
+        let between = &source[comment.end..delete_start];
+        if !between.chars().all(char::is_whitespace)
+            || between.bytes().filter(|byte| *byte == b'\n').count() != 1
+        {
+            break;
+        }
+
+        let comment_line_start = source[..comment.start]
+            .rfind('\n')
+            .map(|pos| pos + 1)
+            .unwrap_or(0);
+        if &source[comment_line_start..comment.start] != field_indent {
+            break;
+        }
+
+        delete_start = comment_line_start;
+    }
+
+    delete_start
 }
 
 /// Determine the indentation level of a from_config block by looking at the source.

--- a/blend/src/nickel/structure_map.rs
+++ b/blend/src/nickel/structure_map.rs
@@ -23,10 +23,6 @@ pub struct RecordInfo {
 /// Structural information about a single field definition
 #[derive(Debug)]
 pub struct FieldInfo {
-    /// Dotted display path relative to the containing from_config (e.g.,
-    /// "font.size"). Display only — segments may contain literal dots.
-    #[allow(dead_code)]
-    pub path: String,
     /// Structured field path with real segment boundaries.
     pub key_path: KeyPath,
     /// Byte range of the entire field definition (from field name to end of value,
@@ -61,14 +57,8 @@ pub struct StructureMap {
     pub nested_records: HashMap<KeyPath, RecordInfo>,
     /// Additional literal-record operands of an outermost `&` merge
     pub merge_partners: Vec<MergePartner>,
-    /// Comment byte ranges within the .ncl source.
-    ///
-    /// TODO: Insert/Delete in `surgical_rewrite_with_structure` does not yet
-    /// consult these ranges, so deleting a field leaves its leading doc
-    /// comment orphaned. See `test_delete_field_should_remove_leading_doc_comment`
-    /// (an inverted `#[should_panic]` test) for the concrete gap this field
-    /// is meant to close.
-    #[allow(dead_code)]
+    /// Comment byte ranges used to remove a deleted field's contiguous leading
+    /// documentation without disturbing comments for adjacent fields.
     pub comments: Vec<Range<usize>>,
 }
 
@@ -585,8 +575,6 @@ fn build_record_info(
         let mut full_segments = path_prefix.segments().to_vec();
         full_segments.extend(segments.iter().cloned());
         let full_key_path = KeyPath::new(full_segments);
-        let full_path = full_key_path.to_string();
-
         // Compute indentation from the first field
         if first_field {
             field_indent = compute_indent(source, field_decl.start_byte());
@@ -613,7 +601,6 @@ fn build_record_info(
         }
 
         fields.push(FieldInfo {
-            path: full_path,
             key_path: full_key_path.clone(),
             full_range: field_start..field_end,
             value_range,
@@ -695,31 +682,6 @@ mod tests {
         KeyPath::new(dotted.split('.').map(str::to_string).collect())
     }
 
-    // -- Helper to dump CST for debugging --
-
-    #[allow(dead_code)]
-    fn dump_cst(node: tree_sitter::Node, source: &str, indent: usize) {
-        let prefix = "  ".repeat(indent);
-        let text = &source[node.start_byte()..node.end_byte()];
-        let display = if text.len() > 60 {
-            format!("{}...", &text[..57])
-        } else {
-            text.to_string()
-        };
-        eprintln!(
-            "{}{} [{}-{}] {:?}",
-            prefix,
-            node.kind(),
-            node.start_byte(),
-            node.end_byte(),
-            display
-        );
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            dump_cst(child, source, indent + 1);
-        }
-    }
-
     // -----------------------------------------------------------------------
     // a. Basic record extraction
     // -----------------------------------------------------------------------
@@ -745,8 +707,8 @@ mod tests {
         assert_eq!(map.root.fields.len(), 2);
 
         // Check field paths
-        assert_eq!(map.root.fields[0].path, "a");
-        assert_eq!(map.root.fields[1].path, "b");
+        assert_eq!(map.root.fields[0].key_path, kp("a"));
+        assert_eq!(map.root.fields[1].key_path, kp("b"));
 
         // Check value ranges point to actual values
         let a_val = &source[map.root.fields[0].value_range.clone()];
@@ -781,7 +743,7 @@ mod tests {
 
         // Root should have one field: "font"
         assert_eq!(map.root.fields.len(), 1);
-        assert_eq!(map.root.fields[0].path, "font");
+        assert_eq!(map.root.fields[0].key_path, kp("font"));
 
         // There should be a nested record at path "font"
         assert!(
@@ -791,8 +753,8 @@ mod tests {
 
         let font_record = &map.nested_records[&kp("font")];
         assert_eq!(font_record.fields.len(), 2);
-        assert_eq!(font_record.fields[0].path, "font.size");
-        assert_eq!(font_record.fields[1].path, "font.family");
+        assert_eq!(font_record.fields[0].key_path, kp("font.size"));
+        assert_eq!(font_record.fields[1].key_path, kp("font.family"));
 
         // Verify nested value ranges
         let size_val = &source[font_record.fields[0].value_range.clone()];
@@ -824,7 +786,7 @@ mod tests {
 
         // The field should have path "font.size" (joined segments)
         assert_eq!(map.root.fields.len(), 1);
-        assert_eq!(map.root.fields[0].path, "font.size");
+        assert_eq!(map.root.fields[0].key_path, kp("font.size"));
     }
 
     // -----------------------------------------------------------------------
@@ -848,7 +810,7 @@ mod tests {
         let map = build_structure_map(source, 0).unwrap();
 
         assert_eq!(map.root.fields.len(), 1);
-        assert_eq!(map.root.fields[0].path, "$schema");
+        assert_eq!(map.root.fields[0].key_path, kp("$schema"));
     }
 
     // -----------------------------------------------------------------------
@@ -929,23 +891,8 @@ mod tests {
         assert!(has_field_comment, "Should find 'Field comment'");
     }
 
-    /// Pins the gap that `StructureMap::comments` exists to close.
-    ///
-    /// `surgical_rewrite_with_structure` deletes a field by removing the byte
-    /// range from line-start to the next newline. A doc comment immediately
-    /// above the deleted field survives — but it now misleadingly precedes
-    /// the next field. The intended fix is for the rewrite path to consult
-    /// `structure.comments`, detect comments attached to the field being
-    /// deleted, and remove them too.
-    ///
-    /// Inverted-status test: marked `#[should_panic]` so the suite "passes"
-    /// while the gap exists. The day the safety check lands, the inner
-    /// `assert!` will succeed, the test will stop panicking, and
-    /// `should_panic` will fail loudly — at which point flip this to a
-    /// regular `#[test]` that asserts the desired behavior directly.
     #[test]
-    #[should_panic(expected = "Doc comment for deleted field should be removed too")]
-    fn test_delete_field_should_remove_leading_doc_comment() {
+    fn delete_field_removes_contiguous_leading_doc_comments() {
         use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
 
         let source = r#"{
@@ -975,71 +922,36 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // g. Real order file: starship
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn test_real_starship_order() {
-        let orders_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
+    fn delete_field_preserves_comments_separated_by_a_blank_line() {
+        use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
+
+        let source = r#"{
+  blend = {
+    files = [
+      {
+        name = "test.toml",
+        from_config = {
+          # Record-level note
+
+          # Field-specific note
+          a = 1,
+          b = 2,
+        },
+      },
+    ],
+  },
+}"#;
+
+        let structure = build_structure_map(source, 0).unwrap();
+        let edits = vec![FieldEdit::Delete { path: kp("a") }];
+        let result = surgical_rewrite_with_structure(source, &structure, &[], &edits, 5)
             .unwrap()
-            .join("orders");
-        let starship_path = orders_dir.join("starship/order.ncl");
-        if !starship_path.exists() {
-            eprintln!("Skipping real order test: {:?} not found", starship_path);
-            return;
-        }
+            .new_source;
 
-        let source = std::fs::read_to_string(&starship_path).unwrap();
-        let map = build_structure_map(&source, 0).unwrap();
-
-        // Starship has known fields
-        let field_paths: Vec<&str> = map.root.fields.iter().map(|f| f.path.as_str()).collect();
-        assert!(
-            field_paths.contains(&"$schema"),
-            "Starship should have $schema field, found: {:?}",
-            field_paths
-        );
-        assert!(
-            field_paths.contains(&"command_timeout"),
-            "Starship should have command_timeout field"
-        );
-        assert!(
-            field_paths.contains(&"git_branch"),
-            "Starship should have git_branch field"
-        );
-        assert!(
-            field_paths.contains(&"shell"),
-            "Starship should have shell field"
-        );
-
-        // Check nested records
-        assert!(
-            map.nested_records.contains_key(&kp("shell")),
-            "Should have nested record for 'shell'"
-        );
-        let shell_record = &map.nested_records[&kp("shell")];
-        let shell_fields: Vec<&str> = shell_record
-            .fields
-            .iter()
-            .map(|f| f.path.as_str())
-            .collect();
-        assert!(
-            shell_fields.contains(&"shell.disabled"),
-            "shell should have disabled field, found: {:?}",
-            shell_fields
-        );
-
-        // Verify comment collection (starship has Nerd Fonts comment)
-        let has_nerd_comment = map
-            .comments
-            .iter()
-            .any(|r| source[r.clone()].contains("Nerd Fonts"));
-        assert!(has_nerd_comment, "Should find Nerd Fonts comment");
-
-        // Field indent should be reasonable (likely 10 spaces for starship)
-        assert!(map.root.field_indent > 0, "Field indent should be non-zero");
+        assert!(result.contains("Record-level note"));
+        assert!(!result.contains("Field-specific note"));
+        assert!(result.contains("b = 2"));
     }
 
     // -----------------------------------------------------------------------
@@ -1097,13 +1009,13 @@ mod tests {
         // Map the first entry
         let map0 = build_structure_map(source, 0).unwrap();
         assert_eq!(map0.root.fields.len(), 1);
-        assert_eq!(map0.root.fields[0].path, "x");
+        assert_eq!(map0.root.fields[0].key_path, kp("x"));
 
         // Map the second entry
         let map1 = build_structure_map(source, 1).unwrap();
         assert_eq!(map1.root.fields.len(), 2);
-        assert_eq!(map1.root.fields[0].path, "y");
-        assert_eq!(map1.root.fields[1].path, "z");
+        assert_eq!(map1.root.fields[0].key_path, kp("y"));
+        assert_eq!(map1.root.fields[1].key_path, kp("z"));
     }
 
     // -----------------------------------------------------------------------
@@ -1158,11 +1070,11 @@ mod tests {
         let parent = map.parent_record(&kp("section.key")).unwrap();
         // It should be the nested record for "section"
         assert!(!parent.fields.is_empty());
-        assert_eq!(parent.fields[0].path, "section.key");
+        assert_eq!(parent.fields[0].key_path, kp("section.key"));
 
         // Parent of "section" should be the root
         let root_parent = map.parent_record(&kp("section")).unwrap();
-        assert_eq!(root_parent.fields[0].path, "section");
+        assert_eq!(root_parent.fields[0].key_path, kp("section"));
     }
 
     #[test]
@@ -1184,10 +1096,10 @@ mod tests {
 }"#;
         let map = build_structure_map(source, 0).unwrap();
         let field_a = map.find_field(&kp("a")).unwrap();
-        assert_eq!(field_a.path, "a");
+        assert_eq!(field_a.key_path, kp("a"));
 
         let field_c = map.find_field(&kp("b.c")).unwrap();
-        assert_eq!(field_c.path, "b.c");
+        assert_eq!(field_c.key_path, kp("b.c"));
 
         assert!(map.find_field(&kp("nonexistent")).is_none());
     }
@@ -1211,18 +1123,23 @@ mod tests {
         let map = build_structure_map(source, 0).unwrap();
 
         // Root (LHS) has a, b
-        let root_paths: Vec<&str> = map.root.fields.iter().map(|f| f.path.as_str()).collect();
-        assert_eq!(root_paths, vec!["a", "b"]);
-
-        // Partner (RHS) has c
-        assert_eq!(map.merge_partners.len(), 1);
-        let partner_paths: Vec<&str> = map.merge_partners[0]
+        let root_paths: Vec<KeyPath> = map
             .root
             .fields
             .iter()
-            .map(|f| f.path.as_str())
+            .map(|field| field.key_path.clone())
             .collect();
-        assert_eq!(partner_paths, vec!["c"]);
+        assert_eq!(root_paths, vec![kp("a"), kp("b")]);
+
+        // Partner (RHS) has c
+        assert_eq!(map.merge_partners.len(), 1);
+        let partner_paths: Vec<KeyPath> = map.merge_partners[0]
+            .root
+            .fields
+            .iter()
+            .map(|field| field.key_path.clone())
+            .collect();
+        assert_eq!(partner_paths, vec![kp("c")]);
 
         // find_field sees both scopes
         assert!(map.find_field(&kp("a")).is_some());
@@ -1256,7 +1173,12 @@ mod tests {
 
         // parent_record(&kp("y.b")) finds the partner's "y" subrecord
         let parent = map.parent_record(&kp("y.b")).unwrap();
-        assert!(parent.fields.iter().any(|f| f.path == "y.b"));
+        assert!(
+            parent
+                .fields
+                .iter()
+                .any(|field| field.key_path == kp("y.b"))
+        );
     }
 
     #[test]
@@ -1286,33 +1208,16 @@ mod tests {
 
         // Only LHS is captured structurally.
         assert!(map.merge_partners.is_empty());
-        let root_paths: Vec<&str> = map.root.fields.iter().map(|f| f.path.as_str()).collect();
-        assert_eq!(root_paths, vec!["a"]);
+        let root_paths: Vec<KeyPath> = map
+            .root
+            .fields
+            .iter()
+            .map(|field| field.key_path.clone())
+            .collect();
+        assert_eq!(root_paths, vec![kp("a")]);
 
         // `b` is reachable via shadow walk's leaf spans, but NOT via the
         // structure map (Insert/Delete on `b` is intentionally unsupported).
         assert!(map.find_field(&kp("b")).is_none());
-    }
-
-    #[test]
-    fn test_merge_real_alacritty_order() {
-        let orders_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("orders");
-        let path = orders_dir.join("alacritty/order.ncl");
-        if !path.exists() {
-            eprintln!("Skipping real alacritty test: {:?} not found", path);
-            return;
-        }
-        let source = std::fs::read_to_string(&path).unwrap();
-        let map = build_structure_map(&source, 0).unwrap();
-
-        // alacritty's from_config is `{ window=..., font=... } & (match ...)`.
-        // We expect window/font to live on root and merge_partners to be empty.
-        let root_paths: Vec<&str> = map.root.fields.iter().map(|f| f.path.as_str()).collect();
-        assert!(root_paths.contains(&"window"));
-        assert!(root_paths.contains(&"font"));
-        assert!(map.merge_partners.is_empty());
     }
 }

--- a/blend/src/state.rs
+++ b/blend/src/state.rs
@@ -25,22 +25,19 @@ pub struct StateStore {
 }
 
 impl StateStore {
-    /// Resolve the snapshots root from the environment.
-    /// Honors `XDG_STATE_HOME`; falls back to `$HOME/.local/state` on every
-    /// platform (including macOS, where `dirs::state_dir()` returns `None`).
-    #[cfg(test)]
-    pub fn from_env() -> Self {
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .expect("HOME must be set");
-        Self::from_env_for_home(&home)
-    }
-
     /// Resolve the state store from the environment, falling back under the
     /// supplied home directory when `XDG_STATE_HOME` is unset.
     pub fn from_env_for_home(home: &Path) -> Self {
-        let base = std::env::var_os("XDG_STATE_HOME")
-            .map(PathBuf::from)
+        let state_home = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
+        Self::for_home_and_state_home(home, state_home.as_deref())
+    }
+
+    /// Resolve the state store from explicit inputs. This keeps callers that
+    /// already know their home/state roots independent of process-global
+    /// environment state.
+    pub fn for_home_and_state_home(home: &Path, state_home: Option<&Path>) -> Self {
+        let base = state_home
+            .map(Path::to_path_buf)
             .unwrap_or_else(|| home.join(".local/state"));
         Self {
             snapshots_root: base.join("blend").join("snapshots"),
@@ -225,72 +222,24 @@ mod tests {
     }
 
     #[test]
-    fn from_env_uses_xdg_state_home_when_set() {
-        // SAFETY: tests in this module are not parallelized over this var.
-        // Use a fresh, unique value to avoid clobbering.
-        let prev = std::env::var_os("XDG_STATE_HOME");
-        // SAFETY: single-threaded test scope.
-        unsafe { std::env::set_var("XDG_STATE_HOME", "/tmp/xdg-state-test") };
-        let store = StateStore::from_env();
+    fn explicit_state_home_takes_precedence() {
+        let store = StateStore::for_home_and_state_home(
+            Path::new("/home/test-user"),
+            Some(Path::new("/tmp/xdg-state-test")),
+        );
         assert_eq!(
             store.snapshots_root,
             PathBuf::from("/tmp/xdg-state-test/blend/snapshots")
         );
-        // SAFETY: restore prior env.
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("XDG_STATE_HOME", v),
-                None => std::env::remove_var("XDG_STATE_HOME"),
-            }
-        }
     }
 
     #[test]
-    fn from_env_falls_back_to_home_local_state() {
-        let prev_xdg = std::env::var_os("XDG_STATE_HOME");
-        let prev_home = std::env::var_os("HOME");
-        // SAFETY: single-threaded test scope.
-        unsafe {
-            std::env::remove_var("XDG_STATE_HOME");
-            std::env::set_var("HOME", "/home/test-user");
-        }
-        let store = StateStore::from_env();
+    fn explicit_resolution_falls_back_to_home_local_state() {
+        let store = StateStore::for_home_and_state_home(Path::new("/home/test-user"), None);
         assert_eq!(
             store.snapshots_root,
             PathBuf::from("/home/test-user/.local/state/blend/snapshots")
         );
-        // SAFETY: restore prior env.
-        unsafe {
-            match prev_xdg {
-                Some(v) => std::env::set_var("XDG_STATE_HOME", v),
-                None => std::env::remove_var("XDG_STATE_HOME"),
-            }
-            match prev_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-    }
-
-    #[test]
-    fn from_env_for_home_falls_back_to_supplied_home() {
-        let prev_xdg = std::env::var_os("XDG_STATE_HOME");
-        // SAFETY: single-threaded test scope.
-        unsafe {
-            std::env::remove_var("XDG_STATE_HOME");
-        }
-        let store = StateStore::from_env_for_home(Path::new("/tmp/blend-home"));
-        assert_eq!(
-            store.snapshots_root,
-            PathBuf::from("/tmp/blend-home/.local/state/blend/snapshots")
-        );
-        // SAFETY: restore prior env.
-        unsafe {
-            match prev_xdg {
-                Some(v) => std::env::set_var("XDG_STATE_HOME", v),
-                None => std::env::remove_var("XDG_STATE_HOME"),
-            }
-        }
     }
 
     #[test]

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -1560,26 +1560,39 @@ fn create_symlink(target: &Path, link: &Path) {
     std::os::unix::fs::symlink(target, link).unwrap();
 }
 
+/// Replace an existing file with an unexpected symlink to identical content.
+/// The returned TempDir keeps the backing file alive for the test duration.
+#[cfg(unix)]
+fn replace_with_unexpected_symlink(target: &Path) -> (TempDir, PathBuf, String) {
+    let content = std::fs::read_to_string(target).unwrap();
+    let backing_dir = TempDir::new().unwrap();
+    let backing_file = backing_dir.path().join(target.file_name().unwrap());
+    std::fs::write(&backing_file, &content).unwrap();
+    std::fs::remove_file(target).unwrap();
+    create_symlink(&backing_file, target);
+    (backing_dir, backing_file, content)
+}
+
 #[test]
 #[cfg(unix)]
 fn test_sync_force_source_to_target_replaces_symlink_with_real_file() {
-    // Simulate a stow-style symlink: target is a symlink to a file with matching content.
+    // The target is an unexpected symlink to a file with matching content.
     // `blend sync --force-source-to-target` should replace the symlink with a real file.
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
 
     // First, create a real file elsewhere with the same content that blend would deploy
-    let stow_dir = TempDir::new().unwrap();
-    let stow_file = stow_dir.path().join("config.txt");
+    let backing_dir = TempDir::new().unwrap();
+    let backing_file = backing_dir.path().join("config.txt");
 
     // Read the source file content to know what blend would deploy
     let source_content =
         std::fs::read_to_string(fixtures_dir().join("orders/plaintext-single/config.txt")).unwrap();
-    std::fs::write(&stow_file, &source_content).unwrap();
+    std::fs::write(&backing_file, &source_content).unwrap();
 
-    // Create a symlink at the target location pointing to the stow file
+    // Create a symlink at the target location pointing to the backing file.
     let target = home.path().join(".config/plaintext-single/config.txt");
-    create_symlink(&stow_file, &target);
+    create_symlink(&backing_file, &target);
 
     // Verify it's a symlink with matching content
     assert!(target.symlink_metadata().unwrap().file_type().is_symlink());
@@ -1617,10 +1630,8 @@ fn test_sync_force_source_to_target_replaces_symlink_with_real_file() {
 
 #[test]
 #[cfg(unix)]
-fn test_sync_force_source_to_target_replaces_symlinked_directory() {
-    // Test that a symlinked directory target also gets replaced with a real directory.
-    // We use test-file which has a from_file entry pointing to a single file,
-    // but we need to test with a from_config entry too.
+fn test_sync_force_source_to_target_replaces_structured_file_symlink() {
+    // Structured from_config entries must obey the same real-file invariant.
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
 
@@ -1636,12 +1647,7 @@ fn test_sync_force_source_to_target_replaces_symlinked_directory() {
     let target = home.path().join(".config/toml-basic/config.toml");
     let expected_content = std::fs::read_to_string(&target).unwrap();
 
-    // Now remove the target and replace with a symlink to a file with same content
-    let stow_dir = TempDir::new().unwrap();
-    let stow_file = stow_dir.path().join("config.toml");
-    std::fs::write(&stow_file, &expected_content).unwrap();
-    std::fs::remove_file(&target).unwrap();
-    create_symlink(&stow_file, &target);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
     assert!(target.symlink_metadata().unwrap().file_type().is_symlink());
 
@@ -1683,14 +1689,7 @@ fn test_view_shows_symlink_annotation() {
     );
 
     let target = home.path().join(".config/plaintext-single/config.txt");
-    let content = std::fs::read_to_string(&target).unwrap();
-
-    // Replace with a symlink to a file with same content
-    let stow_dir = TempDir::new().unwrap();
-    let stow_file = stow_dir.path().join("config.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&target).unwrap();
-    create_symlink(&stow_file, &target);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
     // View should show the symlink annotation
     let output = run_blend(home.path(), &orders, &["view", "plaintext-single"]);
@@ -1724,14 +1723,7 @@ fn test_sync_interactive_replaces_symlink_automatically() {
     );
 
     let target = home.path().join(".config/plaintext-single/config.txt");
-    let content = std::fs::read_to_string(&target).unwrap();
-
-    // Replace with symlink
-    let stow_dir = TempDir::new().unwrap();
-    let stow_file = stow_dir.path().join("config.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&target).unwrap();
-    create_symlink(&stow_file, &target);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
     // Run sync without --force-source-to-target (interactive mode), but since there's no content
     // diff, the symlink replacement should happen automatically without prompting.
@@ -1767,14 +1759,7 @@ fn test_sync_dry_run_detects_symlink_but_does_not_replace() {
     );
 
     let target = home.path().join(".config/plaintext-single/config.txt");
-    let content = std::fs::read_to_string(&target).unwrap();
-
-    // Replace with symlink
-    let stow_dir = TempDir::new().unwrap();
-    let stow_file = stow_dir.path().join("config.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&target).unwrap();
-    create_symlink(&stow_file, &target);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
     // Dry run should detect but not modify
     let output = run_blend(
@@ -1798,7 +1783,7 @@ fn test_sync_dry_run_detects_symlink_but_does_not_replace() {
 }
 
 /// Inner-file leftover scenario: the deployed *directory* is a real dir,
-/// but one file inside it is still a stow-style symlink. Status, view, and
+/// but one file inside it is an unexpected symlink. Status, view, and
 /// sync must all surface and replace it — these were silent before.
 #[test]
 #[cfg(unix)]
@@ -1815,14 +1800,7 @@ fn test_status_shows_symlinked_for_inner_file_symlink() {
     assert!(deploy.status.success());
 
     let inner = home.path().join(".config/plaintext-dir/conf/file1.txt");
-    let content = std::fs::read_to_string(&inner).unwrap();
-
-    // Replace just file1.txt with a symlink to identical content
-    let stow = TempDir::new().unwrap();
-    let stow_file = stow.path().join("file1.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&inner).unwrap();
-    create_symlink(&stow_file, &inner);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&inner);
     assert!(inner.symlink_metadata().unwrap().file_type().is_symlink());
 
     let output = run_blend(home.path(), &orders, &[]);
@@ -1846,12 +1824,7 @@ fn test_view_annotates_inner_file_symlink() {
     );
 
     let inner = home.path().join(".config/plaintext-dir/conf/file1.txt");
-    let content = std::fs::read_to_string(&inner).unwrap();
-    let stow = TempDir::new().unwrap();
-    let stow_file = stow.path().join("file1.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&inner).unwrap();
-    create_symlink(&stow_file, &inner);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&inner);
 
     let output = run_blend(home.path(), &orders, &["view", "plaintext-dir"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1880,12 +1853,7 @@ fn test_sync_interactive_auto_replaces_inner_file_symlink() {
     );
 
     let inner = home.path().join(".config/plaintext-dir/conf/file1.txt");
-    let content = std::fs::read_to_string(&inner).unwrap();
-    let stow = TempDir::new().unwrap();
-    let stow_file = stow.path().join("file1.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&inner).unwrap();
-    create_symlink(&stow_file, &inner);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&inner);
 
     // Interactive sync (no --force-source-to-target) — must NOT prompt because there's no
     // content diff, only a structural symlink mismatch.
@@ -1909,12 +1877,7 @@ fn test_sync_force_source_to_target_replaces_inner_file_symlink() {
     );
 
     let inner = home.path().join(".config/plaintext-dir/conf/file1.txt");
-    let content = std::fs::read_to_string(&inner).unwrap();
-    let stow = TempDir::new().unwrap();
-    let stow_file = stow.path().join("file1.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&inner).unwrap();
-    create_symlink(&stow_file, &inner);
+    let (_backing_dir, backing_file, content) = replace_with_unexpected_symlink(&inner);
     assert!(inner.symlink_metadata().unwrap().file_type().is_symlink());
 
     let output = run_blend(
@@ -1927,37 +1890,37 @@ fn test_sync_force_source_to_target_replaces_inner_file_symlink() {
         !inner.symlink_metadata().unwrap().file_type().is_symlink(),
         "Inner file must be a real file after forced source-to-target"
     );
-    // Stow source must remain untouched (forced source-to-target must not write through the symlink)
-    assert_eq!(std::fs::read_to_string(&stow_file).unwrap(), content);
+    // The backing file must remain untouched: sync must not write through the symlink.
+    assert_eq!(std::fs::read_to_string(&backing_file).unwrap(), content);
 }
 
 #[test]
 #[cfg(unix)]
 fn test_view_annotates_symlink_when_content_also_differs() {
     // Real-world ncdu shape: parent directory of the target is a symlink
-    // to a legacy stow tree, AND the resolved file content differs from
+    // to a backing tree, AND the resolved file content differs from
     // the source. View must show BOTH the diff and the symlink annotation,
     // not just the diff (otherwise the user can't tell that a redeploy
     // is needed to restructure the path).
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
 
-    // Build the stow-style tree at a path outside home, then symlink
+    // Build a backing tree outside home, then symlink
     // the parent directory in.
-    let stow = TempDir::new().unwrap();
-    let stow_order = stow.path().join("plaintext-single");
-    std::fs::create_dir_all(&stow_order).unwrap();
-    std::fs::write(stow_order.join("config.txt"), "old stow content\n").unwrap();
+    let backing = TempDir::new().unwrap();
+    let backing_order = backing.path().join("plaintext-single");
+    std::fs::create_dir_all(&backing_order).unwrap();
+    std::fs::write(backing_order.join("config.txt"), "old backing content\n").unwrap();
 
     let parent = home.path().join(".config/plaintext-single");
     std::fs::create_dir_all(parent.parent().unwrap()).unwrap();
-    create_symlink(&stow_order, &parent);
+    create_symlink(&backing_order, &parent);
 
     // Sanity: target resolves through the symlink to differing content.
     let target = parent.join("config.txt");
     assert_eq!(
         std::fs::read_to_string(&target).unwrap(),
-        "old stow content\n"
+        "old backing content\n"
     );
     assert!(
         parent.symlink_metadata().unwrap().file_type().is_symlink(),
@@ -1973,7 +1936,7 @@ fn test_view_annotates_symlink_when_content_also_differs() {
     );
     // And the content diff must still be shown
     assert!(
-        stdout.contains("old stow content"),
+        stdout.contains("old backing content"),
         "view must still show the content diff:\n{stdout}"
     );
 }
@@ -1992,14 +1955,7 @@ fn test_status_shows_symlink_mismatch() {
     );
 
     let target = home.path().join(".config/plaintext-single/config.txt");
-    let content = std::fs::read_to_string(&target).unwrap();
-
-    // Replace with symlink
-    let stow_dir = TempDir::new().unwrap();
-    let stow_file = stow_dir.path().join("config.txt");
-    std::fs::write(&stow_file, &content).unwrap();
-    std::fs::remove_file(&target).unwrap();
-    create_symlink(&stow_file, &target);
+    let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
     // Status should show "symlinked" status
     let output = run_blend(home.path(), &orders, &[]);


### PR DESCRIPTION
## Summary

- replace process-global test environment mutation with explicit state roots
- remove stale helpers, allowances, and repository-dependent tests
- remove attached comments when deleting Nickel fields while preserving separated comments
- consolidate unexpected-symlink end-to-end fixtures around the lasting invariant

## Validation

- cargo fmt --all -- --check
- cargo clippy --release --all-targets -- -D warnings
- cargo test --release (repeated parallel runs; 227 unit and 68 end-to-end tests)
- cargo run --release -- check
- cargo run --release -- format --check

## Summary by Sourcery

Stabilize blend state and symlink behavior while removing obsolete code and improving Nickel field deletion handling.

Bug Fixes:
- Remove comments attached to deleted Nickel fields while preserving comments separated by blank lines.
- Stabilize symlink handling tests around the invariant that unexpected symlinks are replaced with real deployed files without modifying their backing files.

Enhancements:
- Replace process-global test environment mutation with explicitly supplied home and state roots.
- Remove stale helpers, unused allowances, obsolete fields, and repository-dependent tests.

Tests:
- Consolidate end-to-end symlink fixtures and coverage for file, structured, and inner-directory symlink cases.