### PR TITLE
feat(blend): implement proper YAML support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +119,12 @@ checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -186,6 +203,7 @@ dependencies = [
  "regex",
  "rexpect",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "similar",
  "tempfile",
@@ -416,6 +434,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +630,16 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "granit-parser"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccd1be9ebf2bd5520dbfcfb72b70ef492f654061299a097056f3e73410e38ec"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1087,6 +1133,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1475,23 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ec1f5cac0eb96063c64b28705255a7ed6e7d77f95c1d25e9f8b8c928006ce1"
+dependencies = [
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]

--- a/ERGO.md
+++ b/ERGO.md
@@ -208,7 +208,7 @@ Features that were in "Improvement Ideas" and are now implemented:
 - **Context-aware shadow walk** — follows active match/if branches using runtime metadata
 - **`--no-rewrite` flag** — disables Target -> Source rewrite for review-only mode
 - **`--dry-run` flag** — preview sync actions without changes
-- **Semantic diffing** — format-aware structured comparison for TOML/JSON/JSONC and JSON-subset YAML
+- **Semantic diffing** — format-aware structured comparison for TOML/JSON/JSONC and YAML 1.2
 - **Per-key interactive sync** — `[s]ource [t]arget s[k]ip [a]ll-source a[l]l-target [q]uit` per changed key for `from_config` entries
 - **Snapshot-backed 3-way prompts** — diffs show `<< Source`, `>> Target`, and `|| Base` when a Base snapshot exists
 - **tree-sitter StructureMap** — CST-based record boundary and field range extraction enabling key insertion/deletion in `.ncl` files

--- a/NEW_BLEND.md
+++ b/NEW_BLEND.md
@@ -7,7 +7,7 @@ blend is a cross-platform dotfiles manager that uses Nickel DSL to define, build
 **Key properties:**
 - Configs defined in Nickel (`.ncl` files) under `orders/`
 - Platform conditionals via Nickel's native `match`/`if` expressions with runtime metadata injection
-- Format-aware rendering: Nickel data evaluates to JSON, then renders to TOML/JSON/JSON-subset-YAML/delimited formats
+- Format-aware rendering: Nickel data evaluates to JSON, then renders to TOML/JSON/YAML 1.2/delimited formats
 - Bidirectional sync: apply Source (`orders/`) to Target files, or apply Target changes back to Source
 - Semantic diffing: structured formats are compared by parsed values, not text
 
@@ -24,7 +24,7 @@ orders/<order>/order.ncl   Nickel source (data + optional logic)
   NickelEvaluator          Injects metadata, evaluates to JSON
         │
         ▼
-  FormatRenderer           Renders JSON → TOML/JSON/JSONC/YAML-subset/delimited/plaintext
+  FormatRenderer           Renders JSON → TOML/JSON/JSONC/YAML 1.2/delimited/plaintext
         │
         ▼
   ~/.config/<app>/file     Deployed config file
@@ -210,7 +210,7 @@ Format is inferred from `name` extension when `format` is not set:
 | `.toml` | Toml |
 | `.jsonc` | Jsonc |
 | `.json` | Json (auto-falls back to JSONC parsing if strict JSON fails) |
-| `.yaml`, `.yml` | Yaml (currently JSON-subset rendering/parsing) |
+| `.yaml`, `.yml` | Yaml (YAML 1.2 Core Schema within Blend's JSON value model) |
 | anything else | Plaintext |
 
 Explicit `format` values: `"toml"`, `"json"`, `"jsonc"`, `"yaml"`, `"space_pair_lines"`, `"space_record_lines"`, `"equals_record_lines"`, `"plaintext"`.
@@ -297,7 +297,7 @@ font_size = metadata.os |> match {
 
 | Format | Diff strategy | How it works |
 |--------|--------------|--------------|
-| TOML, JSON, JSON-subset YAML | Semantic diff | Parse both sides to JSON values, compare by key/value |
+| TOML, JSON, YAML 1.2 | Semantic diff | Parse both sides to JSON values, compare by key/value |
 | SpaceRecordLines, EqualsRecordLines | Semantic diff | Parse to key-value map, compare |
 | SpacePairLines, Plaintext | Text diff | Line-by-line unified diff |
 
@@ -358,7 +358,7 @@ blend init                         Generate/refresh orders contract + metadata f
 | `Toml` | `TomlRenderer` | starship, aerospace, alacritty | JSON → TOML via `toml` crate | TOML → JSON |
 | `Json` | `JsonRenderer` | vscode settings | JSON → pretty JSON | JSON → JSON (auto-falls back to JSONC) |
 | `Jsonc` | `JsoncRenderer` | JSONC files | JSON → pretty JSON | Strips comments + trailing commas → JSON |
-| `Yaml` | `JsonRenderer` | pueue | JSON output, valid as YAML 1.2 subset | JSON/JSONC parser only |
+| `Yaml` | `YamlRenderer` | pueue, rancher-desktop | Deterministic block-style YAML 1.2 | YAML 1.2 Core Schema; anchors and merge keys expand to JSON values |
 | `SpacePairLines` | `SpacePairLinesRenderer` | kitty | Array of `[key, val]` → `key val\n` lines | Lines → pairs |
 | `SpaceRecordLines` | `SpaceRecordLinesRenderer` | ncdu | Object → `key val\n` lines | Lines → object |
 | `EqualsRecordLines` | `EqualsRecordLinesRenderer` | npm | Object → `key=val\n` lines | Lines → object |
@@ -405,7 +405,7 @@ Detected at startup and injected by wrapping the canonical
 | **Template syntax embedded in target files** | No | Sometimes | Yes | Yes | **No** |
 | **Structured config as source** | No | No | Partial | Partial | **Yes** |
 | **Native conditionals** | No | File variants | Template logic | Template logic | **Nickel `match` / `if`** |
-| **Format-aware rendering** | No | No | Mostly text templates | Template-driven | **TOML / JSON / JSONC / JSON-subset YAML / delimited** |
+| **Format-aware rendering** | No | No | Mostly text templates | Template-driven | **TOML / JSON / JSONC / YAML 1.2 / delimited** |
 | **Semantic diff** | No | No | Limited | Limited | **Yes** |
 | **Reverse sync for generated configs** | N/A via symlinks | Weak | Partial/manual | Strongest among peers | **Partial, context-aware** |
 | **Good fit for GUI-mutated configs** | Only while symlinks stay healthy | Mixed | Mixed | Better | **Good, with partial automatic source rewrite and manual fallback for non-rewritable logic** |
@@ -445,7 +445,7 @@ The explicit build model enables all three, at the cost of needing the shadow wa
 ### Diff ignore strategy
 
 Single `ignore` field, interpreted based on format:
-- Structured formats (TOML/JSON/JSON-subset YAML): key paths filtered recursively from JSON values before comparison
+- Structured formats (TOML/JSON/YAML 1.2): key paths filtered recursively from JSON values before comparison
 - Text formats (Plaintext, SpacePairLines): regex patterns filtering lines
 
 ### Non-ASCII handling
@@ -467,5 +467,4 @@ In `.ncl` files, use `\u{xxxx}` escape sequences for non-ASCII characters (e.g.,
 - **Secrets management** — integration with system keychains or sops
 - **INI format renderer** — for git config and similar `[section]` formats
 - **`--no-rewrite` info display** — show branch context and Nickel snippets when Target -> Source rewrite is disabled
-- **Full YAML parser/renderer** — current `Yaml` uses JSON-compatible output and JSON/JSONC parsing
 - **Watch mode** — auto-sync on source file changes

--- a/blend/Cargo.toml
+++ b/blend/Cargo.toml
@@ -20,6 +20,7 @@ codespan = "0.13"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde-saphyr = "=1.1.0"
 toml = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 json-strip-comments = "3"

--- a/blend/src/commands/sync.rs
+++ b/blend/src/commands/sync.rs
@@ -216,31 +216,69 @@ pub fn cmd_sync(
 
             // For from_config entries in interactive mode, use per-key flow
             let is_from_config = !result.is_plaintext && !result.is_symlink;
-            // Per-key only works if the deployed file can be semantically parsed
-            let deployed_parseable = if is_from_config {
-                let format = result.format;
-                std::fs::read_to_string(&result.target)
-                    .ok()
-                    .and_then(|s| get_renderer(format).parse(&s).ok())
-                    .is_some()
-            } else {
-                false
-            };
+            // Malformed Target data cannot participate in a semantic merge, but
+            // whole-file interactive mode can still repair it from Source.
             let use_per_key = is_from_config
                 && matches!(mode, SyncMode::Interactive)
                 && !ctx.dry_run
                 && can_pull
-                && deployed_parseable;
+                && std::fs::read_to_string(&result.target)
+                    .ok()
+                    .is_some_and(|content| get_renderer(result.format).parse(&content).is_ok());
 
             if use_per_key {
                 // Per-key interactive sync for from_config entries
                 let format = result.format;
-                let key_changes = semantic_diff_keys(
+                let format_renderer = get_renderer(format);
+                let deployed_content = match std::fs::read_to_string(&result.target) {
+                    Ok(content) => content,
+                    Err(error) => {
+                        log::error(&format!(
+                            "Could not read Target for semantic merge of {}:{}: {}",
+                            order_name, result.name, error
+                        ));
+                        build_errors += 1;
+                        continue;
+                    }
+                };
+                let source_json = match format_renderer.parse(&result.content) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        log::error(&format!(
+                            "Could not parse generated {:?} for semantic merge of {}:{}: {}",
+                            format, order_name, result.name, error
+                        ));
+                        build_errors += 1;
+                        continue;
+                    }
+                };
+                let target_json = match format_renderer.parse(&deployed_content) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        log::error(&format!(
+                            "Could not parse Target {:?} for semantic merge of {}:{}: {}",
+                            format, order_name, result.name, error
+                        ));
+                        build_errors += 1;
+                        continue;
+                    }
+                };
+                let key_changes = match semantic_diff_keys(
                     format,
                     &result.content,
-                    &std::fs::read_to_string(&result.target).unwrap_or_default(),
+                    &deployed_content,
                     &result.ignore_keys,
-                );
+                ) {
+                    Ok(changes) => changes,
+                    Err(error) => {
+                        log::error(&format!(
+                            "Could not compute semantic merge for {}:{}: {}",
+                            order_name, result.name, error
+                        ));
+                        build_errors += 1;
+                        continue;
+                    }
+                };
 
                 if key_changes.is_empty() {
                     if ctx.verbose {
@@ -281,15 +319,6 @@ pub fn cmd_sync(
                         None
                     }
                 };
-                let rendered_json_for_annot: serde_json::Value = get_renderer(format)
-                    .parse(&result.content)
-                    .unwrap_or_default();
-                let deployed_json_for_annot: serde_json::Value =
-                    std::fs::read_to_string(&result.target)
-                        .ok()
-                        .and_then(|s| get_renderer(format).parse(&s).ok())
-                        .unwrap_or_default();
-
                 // Display file header
                 let target_display = sync::shorten_path(&result.target, &ctx.home_dir);
                 println!(
@@ -313,8 +342,8 @@ pub fn cmd_sync(
                     } else {
                         let key_annotation = sync::compute_key_annotation(
                             snapshot_json.as_ref(),
-                            &rendered_json_for_annot,
-                            &deployed_json_for_annot,
+                            &source_json,
+                            &target_json,
                             &change.path,
                         );
                         let prompt_change =
@@ -416,14 +445,6 @@ pub fn cmd_sync(
                     skipped += 1;
                     continue;
                 }
-
-                let format_renderer = get_renderer(format);
-                let source_json: serde_json::Value =
-                    format_renderer.parse(&result.content).unwrap_or_default();
-                let target_json: serde_json::Value = std::fs::read_to_string(&result.target)
-                    .ok()
-                    .and_then(|s| format_renderer.parse(&s).ok())
-                    .unwrap_or_default();
 
                 // Build merged JSON from the decisions that actually applied
                 let merged = sync::build_merged_json(&source_json, &target_json, &decisions);

--- a/blend/src/diff/semantic.rs
+++ b/blend/src/diff/semantic.rs
@@ -5,6 +5,7 @@ use crate::formats::get_renderer;
 use crate::nickel::Format;
 use crate::nickel::ast_utils::json_get_segments;
 use crate::nickel::key_path::{KeyPath, display_segment};
+use crate::output::log;
 
 use super::DiffResult;
 
@@ -45,25 +46,17 @@ pub fn semantic_diff_keys(
     generated: &str,
     deployed: &str,
     ignore_keys: &[String],
-) -> Vec<KeyChange> {
+) -> anyhow::Result<Vec<KeyChange>> {
     let renderer = get_renderer(format);
-
-    let gen_value = match renderer.parse(generated) {
-        Ok(v) => v,
-        Err(_) => return vec![],
-    };
-
-    let dep_value = match renderer.parse(deployed) {
-        Ok(v) => v,
-        Err(_) => return vec![],
-    };
+    let gen_value = renderer.parse(generated)?;
+    let dep_value = renderer.parse(deployed)?;
 
     let gen_filtered = filter_keys(&gen_value, ignore_keys);
     let dep_filtered = filter_keys(&dep_value, ignore_keys);
 
     let mut changes = Vec::new();
     collect_key_changes(&gen_filtered, &dep_filtered, &KeyPath::root(), &mut changes);
-    changes
+    Ok(changes)
 }
 
 /// Recursively collect per-key changes between two JSON values.
@@ -211,12 +204,22 @@ pub fn semantic_diff(
 
     let gen_value = match renderer.parse(generated) {
         Ok(v) => v,
-        Err(_) => return super::text::text_diff(generated, deployed, &[]),
+        Err(error) => {
+            log::warn(&format!(
+                "Could not parse generated {format:?} for semantic diff: {error}; showing textual diff"
+            ));
+            return super::text::text_diff(generated, deployed, &[]);
+        }
     };
 
     let dep_value = match renderer.parse(deployed) {
         Ok(v) => v,
-        Err(_) => return super::text::text_diff(generated, deployed, &[]),
+        Err(error) => {
+            log::warn(&format!(
+                "Could not parse deployed {format:?} for semantic diff: {error}; showing textual diff"
+            ));
+            return super::text::text_diff(generated, deployed, &[]);
+        }
     };
 
     // Filter out ignored keys
@@ -247,17 +250,32 @@ pub fn semantic_diff_with_base(
 
     let gen_value = match renderer.parse(generated) {
         Ok(v) => v,
-        Err(_) => return super::text::text_diff_with_base(generated, deployed, base, &[]),
+        Err(error) => {
+            log::warn(&format!(
+                "Could not parse generated {format:?} for semantic diff: {error}; showing textual diff"
+            ));
+            return super::text::text_diff_with_base(generated, deployed, base, &[]);
+        }
     };
 
     let dep_value = match renderer.parse(deployed) {
         Ok(v) => v,
-        Err(_) => return super::text::text_diff_with_base(generated, deployed, base, &[]),
+        Err(error) => {
+            log::warn(&format!(
+                "Could not parse deployed {format:?} for semantic diff: {error}; showing textual diff"
+            ));
+            return super::text::text_diff_with_base(generated, deployed, base, &[]);
+        }
     };
 
     let base_value = match renderer.parse(base) {
         Ok(v) => v,
-        Err(_) => return semantic_diff(format, generated, deployed, ignore_keys),
+        Err(error) => {
+            log::warn(&format!(
+                "Could not parse snapshot {format:?} for semantic diff: {error}; showing two-way diff"
+            ));
+            return semantic_diff(format, generated, deployed, ignore_keys);
+        }
     };
 
     let gen_filtered = filter_keys(&gen_value, ignore_keys);
@@ -600,15 +618,22 @@ mod tests {
     #[test]
     fn test_semantic_diff_keys_no_changes() {
         let config = r#"{"key": "value"}"#;
-        let changes = semantic_diff_keys(Format::Json, config, config, &[]);
+        let changes = semantic_diff_keys(Format::Json, config, config, &[]).unwrap();
         assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn test_semantic_diff_keys_propagates_parse_failures() {
+        let error = semantic_diff_keys(Format::Yaml, "valid: true\n", "invalid: [\n", &[])
+            .expect_err("invalid YAML must not become an empty change list");
+        assert!(error.to_string().contains("Failed to parse YAML"));
     }
 
     #[test]
     fn test_semantic_diff_keys_modified() {
         let generated = r#"{"key": "new", "other": 1}"#;
         let deployed = r#"{"key": "old", "other": 1}"#;
-        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]);
+        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].path.to_string(), "key");
         assert_eq!(changes[0].change_type, KeyChangeType::Modified);
@@ -622,7 +647,7 @@ mod tests {
     fn test_key_change_with_base_display_shows_base_side() {
         let generated = r#"{"key": "new"}"#;
         let deployed = r#"{"key": "old"}"#;
-        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]);
+        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]).unwrap();
         let base = json!({"key": "original"});
         let change = key_change_with_base_display(&changes[0], Some(&base));
         assert!(change.display.contains("<< Source: \"new\""));
@@ -634,7 +659,7 @@ mod tests {
     fn test_semantic_diff_keys_added_and_removed() {
         let generated = r#"{"repo_only": 1, "shared": true}"#;
         let deployed = r#"{"deployed_only": 2, "shared": true}"#;
-        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]);
+        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]).unwrap();
         assert_eq!(changes.len(), 2);
 
         let added = changes
@@ -656,7 +681,7 @@ mod tests {
     fn test_semantic_diff_keys_nested() {
         let generated = r#"{"section": {"a": 1, "b": 2}}"#;
         let deployed = r#"{"section": {"a": 1, "b": 3}}"#;
-        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]);
+        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].path.to_string(), "section.b");
         assert_eq!(changes[0].path.segments(), ["section", "b"]);
@@ -669,7 +694,7 @@ mod tests {
         let generated = r#"{"[javascript]": {"editor.codeActionsOnSave": {"source.fixAll.eslint": "explicit"}}}"#;
         let deployed =
             r#"{"[javascript]": {"editor.codeActionsOnSave": {"source.fixAll.eslint": "always"}}}"#;
-        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]);
+        let changes = semantic_diff_keys(Format::Json, generated, deployed, &[]).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(
             changes[0].path.segments(),
@@ -690,7 +715,8 @@ mod tests {
     fn test_semantic_diff_keys_ignores_keys() {
         let generated = r#"{"keep": "new", "skip": "new"}"#;
         let deployed = r#"{"keep": "old", "skip": "old"}"#;
-        let changes = semantic_diff_keys(Format::Json, generated, deployed, &["skip".to_string()]);
+        let changes =
+            semantic_diff_keys(Format::Json, generated, deployed, &["skip".to_string()]).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].path.to_string(), "keep");
     }

--- a/blend/src/formats.rs
+++ b/blend/src/formats.rs
@@ -3,6 +3,7 @@ mod json;
 mod jsonc;
 mod plaintext;
 mod toml;
+mod yaml;
 
 use anyhow::Result;
 
@@ -13,6 +14,7 @@ pub use self::json::JsonRenderer;
 pub use self::jsonc::JsoncRenderer;
 pub use self::plaintext::PlaintextRenderer;
 pub use self::toml::TomlRenderer;
+pub use self::yaml::YamlRenderer;
 
 use crate::nickel::Format;
 
@@ -30,7 +32,7 @@ pub fn get_renderer(format: Format) -> Box<dyn FormatRenderer> {
     match format {
         Format::Toml => Box::new(TomlRenderer),
         Format::Json => Box::new(JsonRenderer),
-        Format::Yaml => Box::new(JsonRenderer), // YAML uses JSON-compatible structure
+        Format::Yaml => Box::new(YamlRenderer),
         Format::SpacePairLines => Box::new(SpacePairLinesRenderer),
         Format::SpaceRecordLines => Box::new(SpaceRecordLinesRenderer),
         Format::EqualsRecordLines => Box::new(EqualsRecordLinesRenderer),

--- a/blend/src/formats/yaml.rs
+++ b/blend/src/formats/yaml.rs
@@ -1,0 +1,898 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde_saphyr::granit_parser::{Event, Parser, ScalarStyle, Span, Tag};
+
+use super::FormatRenderer;
+
+const MAX_YAML_EVENTS: usize = 100_000;
+const MAX_YAML_NODES: usize = 100_000;
+const MAX_YAML_DEPTH: usize = 128;
+const MAX_YAML_ALIASES: usize = 1_000;
+
+/// YAML 1.2 renderer/parser for Blend's JSON-compatible value model.
+pub struct YamlRenderer;
+
+#[derive(Clone, Debug)]
+enum YamlNode {
+    Scalar {
+        value: String,
+        style: ScalarStyle,
+        tag: Option<Tag>,
+        span: Span,
+    },
+    Sequence {
+        values: Vec<YamlNode>,
+        tag: Option<Tag>,
+        span: Span,
+    },
+    Mapping {
+        entries: Vec<(YamlNode, YamlNode)>,
+        tag: Option<Tag>,
+        span: Span,
+    },
+}
+
+#[derive(Debug)]
+enum Frame {
+    Sequence {
+        values: Vec<YamlNode>,
+        anchor: usize,
+        tag: Option<Tag>,
+        span: Span,
+    },
+    Mapping {
+        entries: Vec<(YamlNode, YamlNode)>,
+        pending_key: Option<Box<YamlNode>>,
+        anchor: usize,
+        tag: Option<Tag>,
+        span: Span,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct Anchor {
+    node: YamlNode,
+    nodes: usize,
+    depth: usize,
+}
+
+#[derive(Default)]
+struct ParseBudget {
+    events: usize,
+    nodes: usize,
+    aliases: usize,
+}
+
+impl ParseBudget {
+    fn event(&mut self, span: Span) -> Result<()> {
+        self.events += 1;
+        if self.events > MAX_YAML_EVENTS {
+            return Err(located_error(span, "YAML event limit exceeded"));
+        }
+        Ok(())
+    }
+
+    fn nodes(&mut self, count: usize, span: Span) -> Result<()> {
+        self.nodes = self
+            .nodes
+            .checked_add(count)
+            .ok_or_else(|| located_error(span, "YAML node limit exceeded"))?;
+        if self.nodes > MAX_YAML_NODES {
+            return Err(located_error(span, "YAML node limit exceeded"));
+        }
+        Ok(())
+    }
+
+    fn alias(&mut self, anchor: &Anchor, parent_depth: usize, span: Span) -> Result<()> {
+        self.aliases += 1;
+        if self.aliases > MAX_YAML_ALIASES {
+            return Err(located_error(span, "YAML alias limit exceeded"));
+        }
+        ensure_depth(parent_depth + anchor.depth, span)?;
+        self.nodes(anchor.nodes, span)
+    }
+}
+
+impl FormatRenderer for YamlRenderer {
+    fn render(&self, value: &serde_json::Value) -> Result<String> {
+        let options = serde_saphyr::ser_options! {
+            indent_step: 2,
+            compact_list_indent: false,
+            prefer_block_scalars: true,
+            quote_all: false,
+            // The library's YAML 1.2 switch also emits a directive. Leaving it
+            // disabled produces conservative quoting without a document header.
+            yaml_12: false,
+        };
+        let output = serde_saphyr::to_string_with_options(value, options)
+            .context("Failed to serialize YAML")?;
+        if output.starts_with("%YAML") || output.starts_with("---") {
+            bail!("YAML serializer emitted an unexpected document directive or marker");
+        }
+        Ok(output)
+    }
+
+    fn parse(&self, content: &str) -> Result<serde_json::Value> {
+        let node = parse_document(content)?;
+        node_to_json(&node, "$", false, 1)
+    }
+}
+
+fn parse_document(content: &str) -> Result<YamlNode> {
+    if content.trim().is_empty() {
+        bail!("Failed to parse YAML: empty YAML stream");
+    }
+
+    let mut anchors = HashMap::<usize, Anchor>::new();
+    let mut frames = Vec::<Frame>::new();
+    let mut root = None;
+    let mut documents = 0usize;
+    let mut budget = ParseBudget::default();
+
+    for next in Parser::new_from_str(content) {
+        let (event, span) = next.map_err(|error| anyhow!("Failed to parse YAML: {error}"))?;
+        budget.event(span)?;
+        match event {
+            Event::StreamStart | Event::StreamEnd | Event::Comment(..) => {}
+            Event::DocumentStart(_, version) => {
+                documents += 1;
+                if documents > 1 {
+                    bail!("Failed to parse YAML: expected exactly one document");
+                }
+                if version.is_some_and(|version| version.major != 1 || version.minor != 2) {
+                    bail!("Failed to parse YAML: only YAML 1.2 documents are supported");
+                }
+            }
+            Event::DocumentEnd => {
+                if !frames.is_empty() {
+                    bail!("Failed to parse YAML: document ended inside a collection");
+                }
+            }
+            Event::Alias(anchor) => {
+                let anchor = anchors
+                    .get(&anchor)
+                    .ok_or_else(|| located_error(span, "undefined or cyclic YAML alias"))?;
+                budget.alias(anchor, frames.len(), span)?;
+                attach_node(anchor.node.clone(), &mut frames, &mut root)?;
+            }
+            Event::Scalar(value, style, anchor, tag) => {
+                ensure_depth(frames.len() + 1, span)?;
+                budget.nodes(1, span)?;
+                let node = YamlNode::Scalar {
+                    value: value.into_owned(),
+                    style,
+                    tag: tag.map(|tag| tag.into_owned()),
+                    span,
+                };
+                if anchor != 0 {
+                    anchors.insert(
+                        anchor,
+                        Anchor {
+                            node: node.clone(),
+                            nodes: 1,
+                            depth: 1,
+                        },
+                    );
+                }
+                attach_node(node, &mut frames, &mut root)?;
+            }
+            Event::SequenceStart(_, anchor, tag) => {
+                ensure_depth(frames.len() + 1, span)?;
+                frames.push(Frame::Sequence {
+                    values: Vec::new(),
+                    anchor,
+                    tag: tag.map(|tag| tag.into_owned()),
+                    span,
+                });
+            }
+            Event::SequenceEnd => {
+                let Some(Frame::Sequence {
+                    values,
+                    anchor,
+                    tag,
+                    span,
+                }) = frames.pop()
+                else {
+                    bail!("Failed to parse YAML: unexpected sequence end");
+                };
+                let node = YamlNode::Sequence { values, tag, span };
+                budget.nodes(1, span)?;
+                if anchor != 0 {
+                    let (nodes, depth) = node_metrics(&node);
+                    anchors.insert(
+                        anchor,
+                        Anchor {
+                            node: node.clone(),
+                            nodes,
+                            depth,
+                        },
+                    );
+                }
+                attach_node(node, &mut frames, &mut root)?;
+            }
+            Event::MappingStart(_, anchor, tag) => {
+                ensure_depth(frames.len() + 1, span)?;
+                frames.push(Frame::Mapping {
+                    entries: Vec::new(),
+                    pending_key: None,
+                    anchor,
+                    tag: tag.map(|tag| tag.into_owned()),
+                    span,
+                });
+            }
+            Event::MappingEnd => {
+                let Some(Frame::Mapping {
+                    entries,
+                    pending_key,
+                    anchor,
+                    tag,
+                    span,
+                }) = frames.pop()
+                else {
+                    bail!("Failed to parse YAML: unexpected mapping end");
+                };
+                if pending_key.is_some() {
+                    bail!("Failed to parse YAML: mapping key has no value");
+                }
+                let node = YamlNode::Mapping { entries, tag, span };
+                budget.nodes(1, span)?;
+                if anchor != 0 {
+                    let (nodes, depth) = node_metrics(&node);
+                    anchors.insert(
+                        anchor,
+                        Anchor {
+                            node: node.clone(),
+                            nodes,
+                            depth,
+                        },
+                    );
+                }
+                attach_node(node, &mut frames, &mut root)?;
+            }
+            _ => bail!("Failed to parse YAML: unsupported parser event"),
+        }
+    }
+
+    if documents != 1 {
+        bail!("Failed to parse YAML: expected exactly one document");
+    }
+    root.ok_or_else(|| anyhow!("Failed to parse YAML: document has no value"))
+}
+
+fn attach_node(node: YamlNode, frames: &mut [Frame], root: &mut Option<YamlNode>) -> Result<()> {
+    match frames.last_mut() {
+        Some(Frame::Sequence { values, .. }) => values.push(node),
+        Some(Frame::Mapping {
+            entries,
+            pending_key,
+            ..
+        }) => {
+            if let Some(key) = pending_key.take() {
+                entries.push((*key, node));
+            } else {
+                *pending_key = Some(Box::new(node));
+            }
+        }
+        None if root.is_none() => *root = Some(node),
+        None => bail!("Failed to parse YAML: document contains more than one root value"),
+    }
+    Ok(())
+}
+
+fn ensure_depth(depth: usize, span: Span) -> Result<()> {
+    if depth > MAX_YAML_DEPTH {
+        Err(located_error(span, "YAML nesting depth limit exceeded"))
+    } else {
+        Ok(())
+    }
+}
+
+fn node_metrics(node: &YamlNode) -> (usize, usize) {
+    match node {
+        YamlNode::Scalar { .. } => (1, 1),
+        YamlNode::Sequence { values, .. } => {
+            let mut nodes = 1;
+            let mut depth = 1;
+            for value in values {
+                let (child_nodes, child_depth) = node_metrics(value);
+                nodes += child_nodes;
+                depth = depth.max(child_depth + 1);
+            }
+            (nodes, depth)
+        }
+        YamlNode::Mapping { entries, .. } => {
+            let mut nodes = 1;
+            let mut depth = 1;
+            for (key, value) in entries {
+                for child in [key, value] {
+                    let (child_nodes, child_depth) = node_metrics(child);
+                    nodes += child_nodes;
+                    depth = depth.max(child_depth + 1);
+                }
+            }
+            (nodes, depth)
+        }
+    }
+}
+
+fn node_to_json(
+    node: &YamlNode,
+    path: &str,
+    mapping_key: bool,
+    depth: usize,
+) -> Result<serde_json::Value> {
+    ensure_depth(depth, node_span(node))?;
+    match node {
+        YamlNode::Scalar {
+            value,
+            style,
+            tag,
+            span,
+        } => scalar_to_json(value, *style, tag.as_ref(), *span, path, mapping_key),
+        YamlNode::Sequence { values, tag, span } => {
+            validate_collection_tag(tag.as_ref(), "seq", *span)?;
+            if mapping_key {
+                return Err(located_error(*span, "YAML mapping keys must be strings"));
+            }
+            values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| {
+                    node_to_json(value, &format!("{path}[{index}]"), false, depth + 1)
+                })
+                .collect::<Result<Vec<_>>>()
+                .map(serde_json::Value::Array)
+        }
+        YamlNode::Mapping { entries, tag, span } => {
+            validate_collection_tag(tag.as_ref(), "map", *span)?;
+            if mapping_key {
+                return Err(located_error(*span, "YAML mapping keys must be strings"));
+            }
+            mapping_to_json(entries, path, depth)
+        }
+    }
+}
+
+fn mapping_to_json(
+    entries: &[(YamlNode, YamlNode)],
+    path: &str,
+    depth: usize,
+) -> Result<serde_json::Value> {
+    let mut merged = BTreeMap::<String, serde_json::Value>::new();
+    let mut explicit = BTreeMap::<String, serde_json::Value>::new();
+    let mut saw_merge = false;
+
+    for (key_node, value_node) in entries {
+        if is_merge_key(key_node) {
+            if saw_merge {
+                return Err(node_error(key_node, "duplicate YAML mapping key \"<<\""));
+            }
+            saw_merge = true;
+            for source in merge_sources(value_node, path, depth + 1)? {
+                for (key, value) in source {
+                    merged.entry(key).or_insert(value);
+                }
+            }
+            continue;
+        }
+
+        let key_value = node_to_json(key_node, path, true, depth + 1)?;
+        let serde_json::Value::String(key) = key_value else {
+            return Err(node_error(
+                key_node,
+                "YAML mapping keys must resolve as strings",
+            ));
+        };
+        if explicit.contains_key(&key) {
+            return Err(node_error(
+                key_node,
+                &format!("duplicate YAML mapping key {key:?}"),
+            ));
+        }
+        let child_path = json_path(path, &key);
+        explicit.insert(
+            key,
+            node_to_json(value_node, &child_path, false, depth + 1)?,
+        );
+    }
+
+    merged.extend(explicit);
+    Ok(serde_json::Value::Object(merged.into_iter().collect()))
+}
+
+fn merge_sources(
+    node: &YamlNode,
+    path: &str,
+    depth: usize,
+) -> Result<Vec<BTreeMap<String, serde_json::Value>>> {
+    let nodes: Vec<(&YamlNode, usize)> = match node {
+        YamlNode::Mapping { .. } => vec![(node, depth)],
+        YamlNode::Sequence {
+            values, tag, span, ..
+        } => {
+            validate_collection_tag(tag.as_ref(), "seq", *span)?;
+            values.iter().map(|value| (value, depth + 1)).collect()
+        }
+        _ => {
+            return Err(node_error(
+                node,
+                "YAML merge value must be a mapping or sequence of mappings",
+            ));
+        }
+    };
+
+    nodes
+        .into_iter()
+        .map(
+            |(node, depth)| match node_to_json(node, path, false, depth)? {
+                serde_json::Value::Object(map) => Ok(map.into_iter().collect()),
+                _ => Err(node_error(
+                    node,
+                    "YAML merge sequence entries must be mappings",
+                )),
+            },
+        )
+        .collect()
+}
+
+fn is_merge_key(node: &YamlNode) -> bool {
+    matches!(
+        node,
+        YamlNode::Scalar {
+            value,
+            style: ScalarStyle::Plain,
+            tag: None,
+            ..
+        } if value == "<<"
+    )
+}
+
+fn scalar_to_json(
+    value: &str,
+    style: ScalarStyle,
+    tag: Option<&Tag>,
+    span: Span,
+    path: &str,
+    mapping_key: bool,
+) -> Result<serde_json::Value> {
+    let core_tag = match tag {
+        Some(tag) => Some(tag.core_suffix().ok_or_else(|| {
+            located_error(span, &format!("unsupported YAML tag {}", tag.original()))
+        })?),
+        None => None,
+    };
+
+    let parsed = match core_tag {
+        Some("str") => serde_json::Value::String(value.to_string()),
+        Some("null") => parse_null(value, span)?,
+        Some("bool") => parse_bool(value, span)?,
+        Some("int") => parse_integer(value, span)?,
+        Some("float") => parse_float(value, span)?,
+        Some(other) => {
+            return Err(located_error(
+                span,
+                &format!("YAML tag !!{other} cannot be applied to a scalar"),
+            ));
+        }
+        None if style != ScalarStyle::Plain => serde_json::Value::String(value.to_string()),
+        None => parse_plain_scalar(value, span)?,
+    };
+
+    if mapping_key && !parsed.is_string() {
+        return Err(located_error(
+            span,
+            &format!("YAML mapping key at {path} must resolve as a string"),
+        ));
+    }
+    Ok(parsed)
+}
+
+fn parse_plain_scalar(value: &str, span: Span) -> Result<serde_json::Value> {
+    if is_null(value) {
+        return Ok(serde_json::Value::Null);
+    }
+    if is_bool(value) {
+        return parse_bool(value, span);
+    }
+    if looks_like_integer(value) {
+        return parse_integer(value, span);
+    }
+    if looks_like_float(value) {
+        return parse_float(value, span);
+    }
+    Ok(serde_json::Value::String(value.to_string()))
+}
+
+fn parse_null(value: &str, span: Span) -> Result<serde_json::Value> {
+    if is_null(value) {
+        Ok(serde_json::Value::Null)
+    } else {
+        Err(located_error(span, "invalid YAML null scalar"))
+    }
+}
+
+fn is_null(value: &str) -> bool {
+    matches!(value, "" | "~" | "null" | "Null" | "NULL")
+}
+
+fn parse_bool(value: &str, span: Span) -> Result<serde_json::Value> {
+    match value {
+        "true" | "True" | "TRUE" => Ok(serde_json::Value::Bool(true)),
+        "false" | "False" | "FALSE" => Ok(serde_json::Value::Bool(false)),
+        _ => Err(located_error(span, "invalid YAML 1.2 boolean scalar")),
+    }
+}
+
+fn is_bool(value: &str) -> bool {
+    matches!(
+        value,
+        "true" | "True" | "TRUE" | "false" | "False" | "FALSE"
+    )
+}
+
+fn looks_like_integer(value: &str) -> bool {
+    if let Some(rest) = value.strip_prefix("0o") {
+        return !rest.is_empty() && rest.bytes().all(|b| matches!(b, b'0'..=b'7'));
+    }
+    if let Some(rest) = value.strip_prefix("0x") {
+        return !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_hexdigit());
+    }
+    let unsigned = value.strip_prefix(['+', '-']).unwrap_or(value);
+    if unsigned.is_empty() {
+        return false;
+    }
+    unsigned.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn parse_integer(value: &str, span: Span) -> Result<serde_json::Value> {
+    if !looks_like_integer(value) {
+        return Err(located_error(span, "invalid YAML integer scalar"));
+    }
+    let (negative, radix, digits) = if let Some(rest) = value.strip_prefix('-') {
+        (true, 10, rest)
+    } else if let Some(rest) = value.strip_prefix('+') {
+        (false, 10, rest)
+    } else if let Some(rest) = value.strip_prefix("0o") {
+        (false, 8, rest)
+    } else if let Some(rest) = value.strip_prefix("0x") {
+        (false, 16, rest)
+    } else {
+        (false, 10, value)
+    };
+
+    let magnitude = u128::from_str_radix(digits, radix)
+        .map_err(|_| located_error(span, "invalid or out-of-range YAML integer"))?;
+    let number = if negative {
+        let max_magnitude = i64::MAX as u128 + 1;
+        if magnitude > max_magnitude {
+            return Err(located_error(
+                span,
+                "YAML integer is outside the JSON range",
+            ));
+        }
+        serde_json::Number::from(if magnitude == max_magnitude {
+            i64::MIN
+        } else {
+            -(magnitude as i64)
+        })
+    } else {
+        serde_json::Number::from(
+            u64::try_from(magnitude)
+                .map_err(|_| located_error(span, "YAML integer is outside the JSON range"))?,
+        )
+    };
+    Ok(serde_json::Value::Number(number))
+}
+
+fn looks_like_float(value: &str) -> bool {
+    if parse_special_float(value).is_some() {
+        return true;
+    }
+    if value.contains('_') {
+        return false;
+    }
+    let unsigned = value.strip_prefix(['+', '-']).unwrap_or(value);
+    (unsigned.contains('.') || unsigned.contains('e') || unsigned.contains('E'))
+        && unsigned.bytes().any(|b| b.is_ascii_digit())
+        && value.parse::<f64>().is_ok()
+}
+
+fn parse_float(value: &str, span: Span) -> Result<serde_json::Value> {
+    if value.contains('_') {
+        return Err(located_error(span, "invalid YAML float scalar"));
+    }
+    let parsed = match parse_special_float(value) {
+        Some(value) => value,
+        None => value
+            .parse::<f64>()
+            .map_err(|_| located_error(span, "invalid YAML float scalar"))?,
+    };
+    let number = serde_json::Number::from_f64(parsed)
+        .ok_or_else(|| located_error(span, "non-finite YAML floats are not supported"))?;
+    Ok(serde_json::Value::Number(number))
+}
+
+fn parse_special_float(value: &str) -> Option<f64> {
+    match value {
+        ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => Some(f64::INFINITY),
+        "-.inf" | "-.Inf" | "-.INF" => Some(f64::NEG_INFINITY),
+        ".nan" | ".NaN" | ".NAN" => Some(f64::NAN),
+        _ => None,
+    }
+}
+
+fn validate_collection_tag(tag: Option<&Tag>, expected: &str, span: Span) -> Result<()> {
+    let Some(tag) = tag else {
+        return Ok(());
+    };
+    if tag.is_yaml_core_schema_tag(expected) {
+        Ok(())
+    } else if tag.is_yaml_core_schema() {
+        Err(located_error(
+            span,
+            &format!(
+                "YAML tag {} cannot be applied to this collection",
+                tag.original()
+            ),
+        ))
+    } else {
+        Err(located_error(
+            span,
+            &format!("unsupported YAML tag {}", tag.original()),
+        ))
+    }
+}
+
+fn node_span(node: &YamlNode) -> Span {
+    match node {
+        YamlNode::Scalar { span, .. }
+        | YamlNode::Sequence { span, .. }
+        | YamlNode::Mapping { span, .. } => *span,
+    }
+}
+
+fn node_error(node: &YamlNode, message: &str) -> anyhow::Error {
+    located_error(node_span(node), message)
+}
+
+fn located_error(span: Span, message: &str) -> anyhow::Error {
+    let marker = span.tag_start().unwrap_or(span.start);
+    anyhow!(
+        "Failed to parse YAML at line {}, column {}: {message}",
+        marker.line(),
+        marker.col() + 1
+    )
+}
+
+fn json_path(parent: &str, key: &str) -> String {
+    if key
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        format!("{parent}.{key}")
+    } else {
+        format!("{parent}[{key:?}]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn renders_deterministic_yaml() {
+        let value = json!({ "z": [1, 2], "a": { "enabled": true } });
+        assert_eq!(
+            YamlRenderer.render(&value).unwrap(),
+            "a:\n  enabled: true\nz:\n  - 1\n  - 2\n"
+        );
+    }
+
+    #[test]
+    fn roundtrips_supported_json_values() {
+        let values = [
+            serde_json::Value::Null,
+            json!(true),
+            json!(42),
+            json!(1.5),
+            json!("yes"),
+            json!([
+                null,
+                false,
+                "001",
+                "0b10",
+                "tRuE",
+                "nUlL",
+                "-0xF",
+                ".iNf",
+                { "nested": "value" }
+            ]),
+        ];
+        for original in values {
+            let rendered = YamlRenderer.render(&original).unwrap();
+            let parsed = YamlRenderer.parse(&rendered).unwrap();
+            assert_eq!(parsed, original, "rendered YAML:\n{rendered}");
+        }
+    }
+
+    #[test]
+    fn parses_yaml_1_2_scalars() {
+        let parsed = YamlRenderer
+            .parse("yes: off\nnull_title: Null\nnull_upper: NULL\ntrue_title: True\ntrue_upper: TRUE\nfalse_title: False\nfalse_upper: FALSE\nnumber: 0247\noctal: 0o247\nhex: 0xF\nfraction: .5\ntime: 190:20:30\n")
+            .unwrap();
+        assert_eq!(parsed["yes"], "off");
+        assert_eq!(parsed["null_title"], serde_json::Value::Null);
+        assert_eq!(parsed["null_upper"], serde_json::Value::Null);
+        assert_eq!(parsed["true_title"], true);
+        assert_eq!(parsed["true_upper"], true);
+        assert_eq!(parsed["false_title"], false);
+        assert_eq!(parsed["false_upper"], false);
+        assert_eq!(parsed["number"], 247);
+        assert_eq!(parsed["octal"], 167);
+        assert_eq!(parsed["hex"], 15);
+        assert_eq!(parsed["fraction"], 0.5);
+        assert_eq!(parsed["time"], "190:20:30");
+    }
+
+    #[test]
+    fn non_core_scalar_spellings_remain_strings() {
+        for scalar in ["0b10", "tRuE", "nUlL", "-0xF", "+0o7", ".iNf"] {
+            let parsed = YamlRenderer.parse(&format!("value: {scalar}\n")).unwrap();
+            assert_eq!(parsed["value"], scalar, "scalar {scalar:?}");
+        }
+
+        for tagged in [
+            "!!int 0b10",
+            "!!bool tRuE",
+            "!!null nUlL",
+            "!!int -0xF",
+            "!!float .iNf",
+        ] {
+            assert!(
+                YamlRenderer.parse(&format!("value: {tagged}\n")).is_err(),
+                "tagged scalar {tagged:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_numeric_separators_do_not_become_numbers() {
+        let parsed = YamlRenderer
+            .parse("double: 1__2\ntrailing: 1_\nhex: 0x_1\nfloat: 1_.5\n")
+            .unwrap();
+        assert_eq!(parsed["double"], "1__2");
+        assert_eq!(parsed["trailing"], "1_");
+        assert_eq!(parsed["hex"], "0x_1");
+        assert_eq!(parsed["float"], "1_.5");
+        assert!(YamlRenderer.parse("value: !!int 1_2\n").is_err());
+        assert!(YamlRenderer.parse("value: !!float 1_.5\n").is_err());
+    }
+
+    #[test]
+    fn accepts_explicit_and_structurally_empty_documents_as_null() {
+        assert_eq!(
+            YamlRenderer.parse("---\n").unwrap(),
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            YamlRenderer.parse("--- null\n...\n").unwrap(),
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn rejects_empty_and_multiple_documents() {
+        assert!(YamlRenderer.parse("").is_err());
+        assert!(YamlRenderer.parse("a: 1\n---\nb: 2\n").is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_and_non_string_keys() {
+        assert!(YamlRenderer.parse("key: 1\nkey: 2\n").is_err());
+        assert!(YamlRenderer.parse("<<: {one: 1}\n<<: {two: 2}\n").is_err());
+        assert!(YamlRenderer.parse("true: value\n").is_err());
+        assert!(YamlRenderer.parse("123: value\n").is_err());
+        assert!(YamlRenderer.parse("[one, two]: value\n").is_err());
+        let parsed = YamlRenderer
+            .parse("\"true\": bool-like\n\"123\": numeric-like\n")
+            .unwrap();
+        assert_eq!(parsed["true"], "bool-like");
+        assert_eq!(parsed["123"], "numeric-like");
+    }
+
+    #[test]
+    fn expands_aliases_and_merge_keys() {
+        let parsed = YamlRenderer
+            .parse("defaults: &defaults\n  retries: 3\n  timeout: 30\nproduction:\n  <<: *defaults\n  timeout: 60\n")
+            .unwrap();
+        assert_eq!(parsed["production"], json!({ "retries": 3, "timeout": 60 }));
+    }
+
+    #[test]
+    fn merge_sequences_use_first_source_precedence() {
+        let parsed = YamlRenderer
+            .parse("first: &first {shared: first, a: 1}\nsecond: &second {shared: second, b: 2}\ncombined:\n  <<: [*first, *second]\n")
+            .unwrap();
+        assert_eq!(
+            parsed["combined"],
+            json!({ "a": 1, "b": 2, "shared": "first" })
+        );
+    }
+
+    #[test]
+    fn merge_sequences_validate_their_tags() {
+        assert!(
+            YamlRenderer
+                .parse("base: &base {value: 1}\nmerged:\n  <<: !Custom [*base]\n")
+                .is_err()
+        );
+        assert!(
+            YamlRenderer
+                .parse("base: &base {value: 1}\nmerged:\n  <<: !!seq [*base]\n")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_numbers_and_unsupported_tags() {
+        assert!(YamlRenderer.parse("value: .inf\n").is_err());
+        assert!(YamlRenderer.parse("value: +.INF\n").is_err());
+        assert!(YamlRenderer.parse("value: -.inf\n").is_err());
+        assert!(YamlRenderer.parse("value: .nan\n").is_err());
+        assert!(YamlRenderer.parse("value: .NaN\n").is_err());
+        assert!(YamlRenderer.parse("value: !Custom text\n").is_err());
+        assert!(
+            YamlRenderer
+                .parse("value: !!timestamp 2026-08-27\n")
+                .is_err()
+        );
+        assert!(YamlRenderer.parse("value: !!binary SGVsbG8=\n").is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_integers() {
+        assert!(YamlRenderer.parse("value: 18446744073709551616\n").is_err());
+        assert!(YamlRenderer.parse("value: -9223372036854775809\n").is_err());
+    }
+
+    #[test]
+    fn enforces_parser_resource_budgets() {
+        let event_heavy = "- 0\n".repeat(MAX_YAML_EVENTS);
+        let event_error = YamlRenderer.parse(&event_heavy).unwrap_err().to_string();
+        assert!(event_error.contains("event limit"), "{event_error}");
+
+        let deeply_nested = format!(
+            "value: {}0{}\n",
+            "[".repeat(MAX_YAML_DEPTH),
+            "]".repeat(MAX_YAML_DEPTH)
+        );
+        let depth_error = YamlRenderer.parse(&deeply_nested).unwrap_err().to_string();
+        assert!(depth_error.contains("depth limit"), "{depth_error}");
+
+        let aliases = vec!["*base"; MAX_YAML_ALIASES + 1].join(", ");
+        let alias_heavy = format!("base: &base {{value: 1}}\nvalues: [{aliases}]\n");
+        let alias_error = YamlRenderer.parse(&alias_heavy).unwrap_err().to_string();
+        assert!(alias_error.contains("alias limit"), "{alias_error}");
+
+        let mut expanding = "a0: &a0 [0]\n".to_string();
+        for index in 1..20 {
+            expanding.push_str(&format!(
+                "a{index}: &a{index} [*a{}, *a{}]\n",
+                index - 1,
+                index - 1
+            ));
+        }
+        let node_error = YamlRenderer.parse(&expanding).unwrap_err().to_string();
+        assert!(node_error.contains("node limit"), "{node_error}");
+    }
+
+    #[test]
+    fn preserves_multiline_strings_semantically() {
+        let parsed = YamlRenderer
+            .parse("message: |-\n  first line\n  second line\n")
+            .unwrap();
+        assert_eq!(parsed["message"], "first line\nsecond line");
+    }
+}

--- a/blend/tests/fixtures/orders/yaml-format/order.ncl
+++ b/blend/tests/fixtures/orders/yaml-format/order.ncl
@@ -1,0 +1,18 @@
+{
+  blend = {
+    prefix = ["~/.config/yaml-format/"],
+    files = [
+      {
+        name = "settings.yaml",
+        from_config = {
+          enabled = true,
+          message = "hello",
+          nested = {
+            count = 2,
+          },
+          ports = [8080, 8443],
+        },
+      },
+    ],
+  },
+}

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -3,8 +3,9 @@
 //! These tests exercise the full sync flow (build → diff → forced source-to-target
 //! and target-to-source modes) without interactive prompts.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 fn blend_binary() -> PathBuf {
@@ -30,6 +31,32 @@ fn run_blend(home: &Path, blend_dir: &Path, args: &[&str]) -> std::process::Outp
         .arg(blend_dir)
         .output()
         .expect("Failed to execute blend")
+}
+
+fn run_blend_with_stdin(
+    home: &Path,
+    blend_dir: &Path,
+    args: &[&str],
+    input: &str,
+) -> std::process::Output {
+    let mut child = Command::new(blend_binary())
+        .args(args)
+        .arg("--home")
+        .arg(home)
+        .arg("--blend-dir")
+        .arg(blend_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to execute blend");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
 }
 
 fn run_blend_in_cwd(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
@@ -1347,6 +1374,112 @@ fn test_sync_force_target_to_source_json_format() {
         ncl_content.contains("16"),
         "order.ncl should have updated fontSize to 16:\n{ncl_content}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// YAML format tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sync_force_source_to_target_yaml_format() {
+    let home = TempDir::new().unwrap();
+    let orders = fixtures_dir();
+
+    let target = home.path().join(".config/yaml-format/settings.yaml");
+    let output = run_blend(
+        home.path(),
+        &orders,
+        &["sync", "--force-source-to-target", "yaml-format"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "YAML source-to-target sync failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target).unwrap(),
+        "enabled: true\nmessage: hello\nnested:\n  count: 2\nports:\n  - 8080\n  - 8443\n"
+    );
+}
+
+#[test]
+fn test_sync_force_target_to_source_accepts_yaml_anchors_and_merge() {
+    let home = TempDir::new().unwrap();
+    let temp_orders = copy_fixture("yaml-format");
+    let orders = temp_orders.path();
+
+    let initial = run_blend(
+        home.path(),
+        orders,
+        &["sync", "--force-source-to-target", "yaml-format"],
+    );
+    assert!(initial.status.success());
+
+    let target = home.path().join(".config/yaml-format/settings.yaml");
+    std::fs::write(
+        &target,
+        "defaults: &defaults\n  count: 3\nenabled: true\nmessage: hello\nnested:\n  <<: *defaults\nports: [8080, 8443]\n",
+    )
+    .unwrap();
+
+    let output = run_blend(
+        home.path(),
+        orders,
+        &["sync", "--force-target-to-source", "yaml-format"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "YAML target-to-source sync failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let source = std::fs::read_to_string(orders_dir(orders).join("yaml-format/order.ncl")).unwrap();
+    assert!(
+        source.contains("count = 3"),
+        "updated YAML was not pulled:\n{source}"
+    );
+    assert!(
+        source.contains("defaults"),
+        "merged YAML key was not pulled:\n{source}"
+    );
+}
+
+#[test]
+fn test_sync_interactive_can_restore_malformed_yaml_target_from_source() {
+    let home = TempDir::new().unwrap();
+    let temp_orders = copy_fixture("yaml-format");
+    let orders = temp_orders.path();
+
+    let initial = run_blend(
+        home.path(),
+        orders,
+        &["sync", "--force-source-to-target", "yaml-format"],
+    );
+    assert!(initial.status.success());
+
+    let target = home.path().join(".config/yaml-format/settings.yaml");
+    let expected = std::fs::read_to_string(&target).unwrap();
+    std::fs::write(&target, "enabled: [\n").unwrap();
+
+    let output = run_blend_with_stdin(home.path(), orders, &["sync", "yaml-format"], "s\n");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "interactive YAML repair failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("[s]ource -> target"),
+        "whole-file repair prompt was not shown:\n{stdout}"
+    );
+    assert!(
+        format!("{stdout}\n{stderr}").contains("showing textual diff"),
+        "YAML parse fallback warning was not visible:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(std::fs::read_to_string(target).unwrap(), expected);
 }
 
 /// Regression test for the vscode `[javascript]` sync-back bug: a nested


### PR DESCRIPTION
## Summary

- add a dedicated YAML 1.2 renderer/parser backed by exactly pinned `serde-saphyr`
- enforce Blend's JSON-compatible value contract: finite supported numbers, string mapping keys, duplicate rejection, one document, core tags, and validated alias/merge expansion
- render deterministic block-style YAML and surface parse failures instead of silently treating them as empty semantic changes
- add unit and end-to-end coverage, including Target-to-Source anchors/merge handling, and update the design docs

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --release` (243 unit tests + 71 E2E tests)
- `cargo run --release -- check --blend-dir ..`
- `cargo run --release -- format --check --blend-dir ..`
- verified `rancher-desktop` renders `disk: 30GiB`

## Summary by Sourcery

Implement standards-compliant YAML 1.2 support with validated parsing, deterministic rendering, and reliable synchronization behavior.

New Features:
- Add full YAML 1.2 parsing and deterministic rendering within Blend’s JSON-compatible value model, including anchors and merge keys.
- Support YAML-based source-to-target and target-to-source synchronization workflows.

Bug Fixes:
- Propagate YAML parsing failures during semantic key comparisons instead of silently treating invalid content as unchanged.
- Allow interactive synchronization to restore malformed targets through whole-file source replacement.

Enhancements:
- Enforce YAML compatibility and safety rules for supported scalars, tags, mapping keys, duplicate keys, documents, aliases, nesting, and resource usage.

Build:
- Pin the serde-saphyr YAML dependency.

Documentation:
- Update design and user documentation to describe YAML 1.2 support and the dedicated YAML renderer/parser.

Tests:
- Add unit and end-to-end coverage for YAML rendering, scalar handling, validation, anchors, merges, malformed-target recovery, and bidirectional synchronization.