### PR TITLE
fix(blend): unify target node reconciliation

### DIFF
--- a/blend/src/commands/helpers.rs
+++ b/blend/src/commands/helpers.rs
@@ -1,8 +1,10 @@
+use anyhow::{Context as _, Result};
 use console::style;
 
-use crate::compose::{BuildResult, discover_orders};
+use crate::compose::{BuildResult, build_glob_set, collect_merged_files, discover_orders};
 use crate::context::Context;
-use crate::diff::{DiffResult, FileDiffResult, diff_configs, diff_directory};
+use crate::diff::{DiffResult, FileDiffResult, diff_configs, diff_managed_files};
+use crate::fs_node::{NodeKind, node_kind};
 use crate::nickel;
 
 pub fn select_orders(ctx: &Context, orders: &[String]) -> Vec<String> {
@@ -15,125 +17,135 @@ pub fn select_orders(ctx: &Context, orders: &[String]) -> Vec<String> {
     selected
 }
 
-/// For directory-style entries: walk the source dir and check whether any
-/// per-file target is itself a symlink. Returns true even when resolved
-/// content matches, so callers can flag unexpected symlinks within an
-/// otherwise in-sync directory.
-pub fn dir_has_inner_symlinks(source_dir: &std::path::Path, target_dir: &std::path::Path) -> bool {
-    diff_directory(source_dir, target_dir, &[])
-        .iter()
-        .any(|f| f.target_is_symlink)
-}
-
-/// True when the only differences in a directory entry are inner-file
-/// symlinks with matching resolved content. Push under this condition
-/// rewrites file types only — no content changes — so sync should
-/// auto-redeploy rather than prompt the user.
-pub fn only_structural_symlink_changes(result: &BuildResult) -> bool {
-    let Some(src) = result.source_path.as_ref() else {
-        return false;
-    };
-    if !src.is_dir() {
-        return false;
-    }
-    let file_diffs = compute_dir_file_diffs(result);
-    if file_diffs.is_empty() {
-        return false;
-    }
-    let mut saw_symlink = false;
-    for f in &file_diffs {
-        if !f.has_changes {
-            continue;
-        }
-        if f.source_only || !f.target_is_symlink || !f.diff_output.is_empty() {
-            return false;
-        }
-        saw_symlink = true;
-    }
-    saw_symlink
-}
-
-/// Check if a target path or any of its parent components is a symlink
-/// when the order entry does NOT want a symlink.
-pub fn target_is_unexpected_symlink(target: &std::path::Path, is_symlink_entry: bool) -> bool {
-    if is_symlink_entry {
-        return false;
-    }
-    // Check the target itself
-    if let Ok(meta) = std::fs::symlink_metadata(target)
-        && meta.file_type().is_symlink()
+pub fn expected_node_kind(result: &BuildResult) -> NodeKind {
+    if result.is_symlink {
+        NodeKind::Symlink
+    } else if result
+        .source_path
+        .as_ref()
+        .is_some_and(|source_path| source_path.is_dir())
     {
-        return true;
+        NodeKind::Directory
+    } else {
+        NodeKind::File
     }
-    // Check parent path components (e.g., ~/.config/skhd is a symlink,
-    // target is ~/.config/skhd/skhdrc which resolves through it)
-    for ancestor in target.ancestors().skip(1) {
-        if ancestor == std::path::Path::new("/") || ancestor == std::path::Path::new("") {
-            break;
-        }
-        if let Ok(meta) = std::fs::symlink_metadata(ancestor) {
-            if meta.file_type().is_symlink() {
-                return true;
-            }
-            // Stop at first real existing ancestor
-            break;
-        }
+}
+
+pub fn target_type_mismatch(result: &BuildResult) -> Result<Option<(NodeKind, NodeKind)>> {
+    let expected = expected_node_kind(result);
+    let Some(actual) = node_kind(&result.target)
+        .with_context(|| format!("could not inspect target {}", result.target.display()))?
+    else {
+        return Ok(None);
+    };
+    Ok((expected != actual).then_some((expected, actual)))
+}
+
+pub fn result_has_type_mismatch(result: &BuildResult) -> Result<bool> {
+    if target_type_mismatch(result)?.is_some() {
+        return Ok(true);
     }
-    false
+    Ok(compute_dir_file_diffs(result)?
+        .iter()
+        .any(FileDiffResult::has_type_mismatch))
+}
+
+pub fn compute_managed_dir_diffs(
+    source_dir: &std::path::Path,
+    target_dir: &std::path::Path,
+    local_dir: Option<&std::path::Path>,
+    exclude_patterns: &[String],
+    ignore_keys: &[String],
+) -> Result<Vec<FileDiffResult>> {
+    let exclude = build_glob_set(exclude_patterns)?;
+    let merged = collect_merged_files(source_dir, local_dir, exclude.as_ref())?;
+    let managed_files: Vec<_> = merged
+        .into_iter()
+        .map(|file| (file.source, file.rel_path))
+        .collect();
+    Ok(diff_managed_files(&managed_files, target_dir, ignore_keys)?)
 }
 
 /// Compute the diff between a build result and the deployed file
-pub fn compute_diff_for_result(result: &BuildResult) -> DiffResult {
-    if result.is_symlink {
-        return DiffResult::no_changes();
+pub fn compute_diff_for_result(result: &BuildResult) -> Result<DiffResult> {
+    let target_kind = node_kind(&result.target)
+        .with_context(|| format!("could not inspect target {}", result.target.display()))?;
+    if target_kind.is_none() {
+        return Ok(DiffResult::no_changes());
     }
 
-    if !result.target.exists() {
-        return DiffResult::no_changes();
+    if let Some((expected, actual)) = target_type_mismatch(result)? {
+        return Ok(DiffResult::with_changes(format!(
+            "target type mismatch: expected {expected}, found {actual}"
+        )));
+    }
+
+    if result.is_symlink {
+        let expected = result
+            .canonical_source
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        return Ok(match std::fs::read_link(&result.target) {
+            Ok(actual) if result.canonical_source.as_ref() == Some(&actual) => {
+                DiffResult::no_changes()
+            }
+            Ok(actual) => DiffResult::with_changes(format!(
+                "symlink target mismatch: expected {expected}, found {}",
+                actual.display()
+            )),
+            Err(error) => {
+                DiffResult::with_changes(format!("could not read target symlink: {error}"))
+            }
+        });
     }
 
     if result.is_plaintext {
         if let Some(source_path) = &result.source_path {
             if source_path.is_dir() {
-                // For directories, compute an aggregate diff from per-file results.
-                // diff_directory only reports files present in the source.
-                let file_diffs = diff_directory(source_path, &result.target, &result.ignore_keys);
-                return aggregate_dir_diff(&file_diffs);
+                let file_diffs = compute_dir_file_diffs(result)?;
+                return Ok(aggregate_dir_diff(&file_diffs));
             }
             if let (Ok(source_content), Ok(deployed)) = (
                 std::fs::read_to_string(source_path),
                 std::fs::read_to_string(&result.target),
             ) {
-                return diff_configs(
+                return Ok(diff_configs(
                     nickel::Format::Plaintext,
                     &source_content,
                     &deployed,
                     &result.ignore_keys,
-                );
+                ));
             }
         }
-        DiffResult::no_changes()
+        Ok(DiffResult::no_changes())
     } else if let Ok(deployed) = std::fs::read_to_string(&result.target) {
-        diff_configs(
+        Ok(diff_configs(
             result.format,
             &result.content,
             &deployed,
             &result.ignore_keys,
-        )
+        ))
     } else {
-        DiffResult::no_changes()
+        Ok(DiffResult::no_changes())
     }
 }
 
 /// Compute per-file diffs for a directory build result, filtering out
 /// "target only" files that are managed by other entries in the same order.
-pub fn compute_dir_file_diffs(result: &BuildResult) -> Vec<FileDiffResult> {
-    if let Some(source_path) = &result.source_path
-        && source_path.is_dir()
+pub fn compute_dir_file_diffs(result: &BuildResult) -> Result<Vec<FileDiffResult>> {
+    if expected_node_kind(result) == NodeKind::Directory
+        && let Some(source_path) = &result.source_path
     {
-        return diff_directory(source_path, &result.target, &result.ignore_keys);
+        return compute_managed_dir_diffs(
+            source_path,
+            &result.target,
+            result.local_dir.as_deref(),
+            &result.exclude_patterns,
+            &result.ignore_keys,
+        );
     }
-    Vec::new()
+    Ok(Vec::new())
 }
 
 /// Aggregate per-file diffs into a single DiffResult (for sync compatibility)
@@ -153,10 +165,15 @@ pub fn aggregate_dir_diff(file_diffs: &[FileDiffResult]) -> DiffResult {
                 style(format!("{} (missing from Target)", path_str)).blue()
             ));
         } else if f.has_changes {
-            let annotation = match (f.target_is_symlink, !f.diff_output.is_empty()) {
-                (true, true) => "unexpected symlink, modified",
-                (true, false) => "unexpected symlink",
-                (false, _) => "modified",
+            let annotation = if let Some(target_kind) = f.target_kind
+                && target_kind != f.expected_kind
+            {
+                format!(
+                    "type mismatch: expected {}, found {}",
+                    f.expected_kind, target_kind
+                )
+            } else {
+                "modified".to_string()
             };
             output_lines.push(format!(
                 "{} {}",
@@ -188,14 +205,16 @@ mod tests {
                 has_changes: false,
                 source_only: false,
                 diff_output: String::new(),
-                target_is_symlink: false,
+                expected_kind: NodeKind::File,
+                target_kind: Some(NodeKind::File),
             },
             FileDiffResult {
                 rel_path: PathBuf::from("b.txt"),
                 has_changes: false,
                 source_only: false,
                 diff_output: String::new(),
-                target_is_symlink: false,
+                expected_kind: NodeKind::File,
+                target_kind: Some(NodeKind::File),
             },
         ];
         let result = aggregate_dir_diff(&diffs);
@@ -209,7 +228,8 @@ mod tests {
             has_changes: true,
             source_only: false,
             diff_output: "diff".to_string(),
-            target_is_symlink: false,
+            expected_kind: NodeKind::File,
+            target_kind: Some(NodeKind::File),
         }];
         let result = aggregate_dir_diff(&diffs);
         assert!(result.has_changes);
@@ -223,7 +243,8 @@ mod tests {
             has_changes: true,
             source_only: true,
             diff_output: String::new(),
-            target_is_symlink: false,
+            expected_kind: NodeKind::File,
+            target_kind: None,
         }];
         let result = aggregate_dir_diff(&diffs);
         let plain = console::strip_ansi_codes(&result.output);
@@ -238,7 +259,8 @@ mod tests {
             has_changes: true,
             source_only: false,
             diff_output: "line diff".to_string(),
-            target_is_symlink: false,
+            expected_kind: NodeKind::File,
+            target_kind: Some(NodeKind::File),
         }];
         let result = aggregate_dir_diff(&diffs);
         let plain = console::strip_ansi_codes(&result.output);
@@ -253,43 +275,44 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_dir_diff_unexpected_symlink_matching_content() {
-        // Inner-file symlink with matching resolved content: surface
-        // the type mismatch even though there is no textual diff.
+    fn test_aggregate_dir_diff_type_mismatch() {
         let diffs = vec![FileDiffResult {
             rel_path: PathBuf::from(".prototools"),
             has_changes: true,
             source_only: false,
             diff_output: String::new(),
-            target_is_symlink: true,
+            expected_kind: NodeKind::File,
+            target_kind: Some(NodeKind::Symlink),
         }];
         let result = aggregate_dir_diff(&diffs);
         let plain = console::strip_ansi_codes(&result.output);
         assert!(result.has_changes);
         assert!(
-            plain.contains(".prototools") && plain.contains("unexpected symlink"),
-            "expected unexpected-symlink annotation, got:\n{plain}"
+            plain.contains(".prototools")
+                && plain.contains("type mismatch: expected file, found symlink"),
+            "expected type-mismatch annotation, got:\n{plain}"
         );
     }
 
     #[test]
-    fn test_aggregate_dir_diff_unexpected_symlink_with_content_diff() {
+    fn test_aggregate_dir_diff_does_not_mix_type_and_content_diffs() {
         let diffs = vec![FileDiffResult {
             rel_path: PathBuf::from(".prototools"),
             has_changes: true,
             source_only: false,
-            diff_output: ">> Target: old\n<< Source: new".to_string(),
-            target_is_symlink: true,
+            diff_output: String::new(),
+            expected_kind: NodeKind::File,
+            target_kind: Some(NodeKind::Symlink),
         }];
         let result = aggregate_dir_diff(&diffs);
         let plain = console::strip_ansi_codes(&result.output);
-        assert!(plain.contains("unexpected symlink"));
-        assert!(plain.contains(">> Target: old"));
+        assert!(plain.contains("type mismatch: expected file, found symlink"));
+        assert!(!plain.contains(">> Target"));
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_dir_has_inner_symlinks_detects_symlink_target() {
+    fn test_managed_dir_diffs_detects_symlink_target() {
         // Per-file detection: for directory entries we must walk into the
         // target dir, not just check the dir's own type.
         let source = TempDir::new().unwrap();
@@ -299,22 +322,32 @@ mod tests {
         std::fs::write(backing.path().join("file"), "x").unwrap();
         std::os::unix::fs::symlink(backing.path().join("file"), target.path().join("file"))
             .unwrap();
-        assert!(dir_has_inner_symlinks(source.path(), target.path()));
+        assert!(
+            compute_managed_dir_diffs(source.path(), target.path(), None, &[], &[])
+                .unwrap()
+                .iter()
+                .any(FileDiffResult::has_type_mismatch)
+        );
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_dir_has_inner_symlinks_false_when_all_regular() {
+    fn test_managed_dir_diffs_has_no_type_mismatch_when_all_regular() {
         let source = TempDir::new().unwrap();
         let target = TempDir::new().unwrap();
         std::fs::write(source.path().join("file"), "x").unwrap();
         std::fs::write(target.path().join("file"), "x").unwrap();
-        assert!(!dir_has_inner_symlinks(source.path(), target.path()));
+        assert!(
+            !compute_managed_dir_diffs(source.path(), target.path(), None, &[], &[])
+                .unwrap()
+                .iter()
+                .any(FileDiffResult::has_type_mismatch)
+        );
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_dir_has_inner_symlinks_only_inspects_files_present_in_source() {
+    fn test_managed_dir_diffs_only_inspects_nodes_present_in_source() {
         // A symlink that exists only in target (no source counterpart)
         // is unmanaged by blend and must NOT trigger the warning, so the
         // detection stays scoped to files originating from the order.
@@ -326,7 +359,12 @@ mod tests {
         std::fs::write(backing.path().join("stray"), "y").unwrap();
         std::os::unix::fs::symlink(backing.path().join("stray"), target.path().join("stray"))
             .unwrap();
-        assert!(!dir_has_inner_symlinks(source.path(), target.path()));
+        assert!(
+            !compute_managed_dir_diffs(source.path(), target.path(), None, &[], &[])
+                .unwrap()
+                .iter()
+                .any(FileDiffResult::has_type_mismatch)
+        );
     }
 
     #[test]
@@ -337,21 +375,24 @@ mod tests {
                 has_changes: true,
                 source_only: true,
                 diff_output: String::new(),
-                target_is_symlink: false,
+                expected_kind: NodeKind::File,
+                target_kind: None,
             },
             FileDiffResult {
                 rel_path: PathBuf::from("modified.txt"),
                 has_changes: true,
                 source_only: false,
                 diff_output: "diff".to_string(),
-                target_is_symlink: false,
+                expected_kind: NodeKind::File,
+                target_kind: Some(NodeKind::File),
             },
             FileDiffResult {
                 rel_path: PathBuf::from("stable.txt"),
                 has_changes: false,
                 source_only: false,
                 diff_output: String::new(),
-                target_is_symlink: false,
+                expected_kind: NodeKind::File,
+                target_kind: Some(NodeKind::File),
             },
         ];
         let result = aggregate_dir_diff(&diffs);
@@ -381,7 +422,104 @@ mod tests {
             local_dir: None,
             immutable: false,
         };
-        assert!(compute_dir_file_diffs(&result).is_empty());
+        assert!(compute_dir_file_diffs(&result).unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_compute_dir_file_diffs_includes_local_overlay_nodes() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        let target = temp.path().join("target");
+        let backing = temp.path().join("backing");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(local.join("local.txt"), "local").unwrap();
+        std::fs::write(&backing, "local").unwrap();
+        std::os::unix::fs::symlink(&backing, target.join("local.txt")).unwrap();
+
+        let result = BuildResult {
+            target,
+            content: String::new(),
+            is_plaintext: true,
+            source_path: Some(source),
+            name: "target".to_string(),
+            format: nickel::Format::Plaintext,
+            ignore_keys: vec![],
+            is_symlink: false,
+            canonical_source: None,
+            exclude_patterns: vec![],
+            local_dir: Some(local),
+            immutable: false,
+        };
+
+        let diffs = compute_dir_file_diffs(&result).unwrap();
+        assert_eq!(diffs.len(), 1);
+        assert!(diffs[0].has_type_mismatch());
+        assert!(result_has_type_mismatch(&result).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_compute_dir_file_diffs_ignores_excluded_nodes() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let target = temp.path().join("target");
+        let backing = temp.path().join("backing");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(source.join("excluded.txt"), "source").unwrap();
+        std::fs::write(&backing, "source").unwrap();
+        std::os::unix::fs::symlink(&backing, target.join("excluded.txt")).unwrap();
+
+        let result = BuildResult {
+            target,
+            content: String::new(),
+            is_plaintext: true,
+            source_path: Some(source),
+            name: "target".to_string(),
+            format: nickel::Format::Plaintext,
+            ignore_keys: vec![],
+            is_symlink: false,
+            canonical_source: None,
+            exclude_patterns: vec!["excluded.txt".to_string()],
+            local_dir: None,
+            immutable: false,
+        };
+
+        assert!(compute_dir_file_diffs(&result).unwrap().is_empty());
+        assert!(!result_has_type_mismatch(&result).unwrap());
+    }
+
+    #[test]
+    fn test_compute_dir_file_diffs_propagates_invalid_exclude_pattern() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let target = temp.path().join("target");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+
+        let result = BuildResult {
+            target,
+            content: String::new(),
+            is_plaintext: true,
+            source_path: Some(source),
+            name: "target".to_string(),
+            format: nickel::Format::Plaintext,
+            ignore_keys: vec![],
+            is_symlink: false,
+            canonical_source: None,
+            exclude_patterns: vec!["[".to_string()],
+            local_dir: None,
+            immutable: false,
+        };
+
+        let error = compute_dir_file_diffs(&result).unwrap_err();
+        assert!(error.to_string().contains("Invalid exclude glob pattern"));
+        assert!(result_has_type_mismatch(&result).is_err());
+        assert!(compute_diff_for_result(&result).is_err());
     }
 
     #[test]
@@ -401,7 +539,7 @@ mod tests {
             local_dir: None,
             immutable: false,
         };
-        assert!(compute_dir_file_diffs(&result).is_empty());
+        assert!(compute_dir_file_diffs(&result).unwrap().is_empty());
     }
 
     #[test]
@@ -425,7 +563,7 @@ mod tests {
             immutable: false,
         };
 
-        let diff = compute_diff_for_result(&result);
+        let diff = compute_diff_for_result(&result).unwrap();
         let plain = console::strip_ansi_codes(&diff.output);
         assert!(diff.has_changes);
         assert!(plain.contains("prefix-extra"));
@@ -457,7 +595,7 @@ mod tests {
             local_dir: None,
             immutable: false,
         };
-        let diffs = compute_dir_file_diffs(&result);
+        let diffs = compute_dir_file_diffs(&result).unwrap();
         assert_eq!(diffs.len(), 2);
         let a = diffs
             .iter()
@@ -496,7 +634,7 @@ mod tests {
             local_dir: None,
             immutable: false,
         };
-        let diffs = compute_dir_file_diffs(&result);
+        let diffs = compute_dir_file_diffs(&result).unwrap();
         assert_eq!(diffs.len(), 1);
         assert!(!diffs[0].has_changes);
     }

--- a/blend/src/commands/status.rs
+++ b/blend/src/commands/status.rs
@@ -1,10 +1,11 @@
 use console::style;
 use rayon::prelude::*;
 
-use crate::commands::helpers::{dir_has_inner_symlinks, target_is_unexpected_symlink};
+use crate::commands::helpers::compute_managed_dir_diffs;
 use crate::compose::{discover_orders, get_order};
 use crate::context::Context;
 use crate::diff::check_file_sync;
+use crate::fs_node::{NodeKind, node_kind};
 use crate::nickel::generated;
 use crate::output::log;
 
@@ -117,65 +118,129 @@ pub fn cmd_status(ctx: &Context) -> anyhow::Result<()> {
                                 format!("{:<file_w$}", source_name)
                             };
 
-                            let (status, diff_display) = if file_entry.symlink {
+                            let expected_kind = if file_entry.symlink {
+                                NodeKind::Symlink
+                            } else if is_dir {
+                                NodeKind::Directory
+                            } else {
+                                NodeKind::File
+                            };
+                            let (target_kind, mut row_error) = match node_kind(&target) {
+                                Ok(kind) => (kind, None),
+                                Err(error) => {
+                                    (None, Some(format!("could not inspect target: {error}")))
+                                }
+                            };
+
+                            let (status, diff_display) = if row_error.is_some() {
+                                (
+                                    style(format!("{:<status_w$}", "error")).red().to_string(),
+                                    style(format!("{:<diff_w$}", "\u{00b7}")).dim().to_string(),
+                                )
+                            } else if file_entry.symlink {
                                 // Symlink entry: check if symlink exists and points correctly
                                 let source_path = ctx
                                     .orders_dir
                                     .join(order_name)
                                     .join(file_entry.from_file.as_deref().unwrap_or(""));
                                 let canonical = source_path.canonicalize().ok();
-                                let linked_ok = match std::fs::read_link(&target) {
-                                    Ok(existing) => {
-                                        canonical.as_deref() == Some(existing.as_path())
-                                    }
-                                    Err(_) => false,
-                                };
-                                if linked_ok {
-                                    (
-                                        style(format!("{:<status_w$}", "linked"))
-                                            .green()
-                                            .to_string(),
-                                        style(format!("{:<diff_w$}", "\u{2713}"))
-                                            .green()
-                                            .to_string(),
-                                    )
-                                } else if target.exists() || target.symlink_metadata().is_ok() {
-                                    (
-                                        style(format!("{:<status_w$}", "linked"))
+                                match target_kind {
+                                    Some(NodeKind::Symlink) => match std::fs::read_link(&target) {
+                                        Ok(existing)
+                                            if canonical.as_deref() == Some(existing.as_path()) =>
+                                        {
+                                            (
+                                                style(format!("{:<status_w$}", "linked"))
+                                                    .green()
+                                                    .to_string(),
+                                                style(format!("{:<diff_w$}", "\u{2713}"))
+                                                    .green()
+                                                    .to_string(),
+                                            )
+                                        }
+                                        Ok(_) => (
+                                            style(format!("{:<status_w$}", "mismatch"))
+                                                .yellow()
+                                                .to_string(),
+                                            style(format!("{:<diff_w$}", "\u{2260}"))
+                                                .yellow()
+                                                .to_string(),
+                                        ),
+                                        Err(error) => {
+                                            row_error = Some(format!(
+                                                "could not read target symlink: {error}"
+                                            ));
+                                            (
+                                                style(format!("{:<status_w$}", "error"))
+                                                    .red()
+                                                    .to_string(),
+                                                style(format!("{:<diff_w$}", "\u{00b7}"))
+                                                    .dim()
+                                                    .to_string(),
+                                            )
+                                        }
+                                    },
+                                    Some(_) => (
+                                        style(format!("{:<status_w$}", "mismatch"))
                                             .yellow()
                                             .to_string(),
                                         style(format!("{:<diff_w$}", "\u{2260}"))
                                             .yellow()
                                             .to_string(),
-                                    )
-                                } else {
-                                    (
+                                    ),
+                                    None => (
                                         style(format!("{:<status_w$}", "pending"))
                                             .yellow()
                                             .to_string(),
                                         style(format!("{:<diff_w$}", "\u{00b7}")).dim().to_string(),
-                                    )
+                                    ),
                                 }
-                            } else if target.exists() || target.symlink_metadata().is_ok() {
-                                // Check for an unexpected target symlink.
-                                // For directory entries, also walk the source dir
-                                // and detect per-file symlinks within the target,
-                                // since the directory itself can be a real dir
-                                // while inner files are still legacy symlinks.
+                            } else if let Some(actual_kind) = target_kind {
                                 let order_dir = ctx.orders_dir.join(order_name);
-                                let unexpected_sym =
-                                    target_is_unexpected_symlink(&target, file_entry.symlink);
-                                let inner_sym = !file_entry.symlink
-                                    && file_entry
-                                        .from_file
+                                let direct_mismatch = actual_kind != expected_kind;
+                                let directory_diffs = if direct_mismatch || !is_dir {
+                                    Ok(None)
+                                } else {
+                                    let source_dir = order_dir
+                                        .join(file_entry.from_file.as_deref().unwrap_or_default());
+                                    let local_dir = file_entry
+                                        .local
                                         .as_ref()
-                                        .map(|f| order_dir.join(f))
-                                        .filter(|p| p.is_dir())
-                                        .is_some_and(|src| dir_has_inner_symlinks(&src, &target));
+                                        .map(|local| order_dir.join(local));
+                                    let mut ignore_keys = order.global_ignore().to_vec();
+                                    ignore_keys.extend(file_entry.ignore.iter().cloned());
+                                    compute_managed_dir_diffs(
+                                        &source_dir,
+                                        &target,
+                                        local_dir.as_deref(),
+                                        &file_entry.exclude,
+                                        &ignore_keys,
+                                    )
+                                    .map(Some)
+                                };
 
-                                if unexpected_sym || inner_sym {
+                                let directory_diffs = match directory_diffs {
+                                    Ok(value) => value,
+                                    Err(error) => {
+                                        row_error = Some(format!(
+                                            "could not build managed inventory: {error}"
+                                        ));
+                                        None
+                                    }
+                                };
+                                let inner_mismatch =
+                                    directory_diffs.as_ref().is_some_and(|diffs| {
+                                        diffs.iter().any(|diff| diff.has_type_mismatch())
+                                    });
+
+                                if row_error.is_some() {
                                     (
-                                        style(format!("{:<status_w$}", "symlinked"))
+                                        style(format!("{:<status_w$}", "error")).red().to_string(),
+                                        style(format!("{:<diff_w$}", "\u{00b7}")).dim().to_string(),
+                                    )
+                                } else if direct_mismatch || inner_mismatch {
+                                    (
+                                        style(format!("{:<status_w$}", "mismatch"))
                                             .yellow()
                                             .to_string(),
                                         style(format!("{:<diff_w$}", "\u{2260}"))
@@ -183,29 +248,47 @@ pub fn cmd_status(ctx: &Context) -> anyhow::Result<()> {
                                             .to_string(),
                                     )
                                 } else {
-                                    let sync = check_file_sync(
-                                        &order_dir,
-                                        file_entry,
-                                        &target,
-                                        order.global_ignore(),
-                                    );
+                                    let sync = if let Some(file_diffs) = directory_diffs {
+                                        Ok((!file_diffs.is_empty()).then(|| {
+                                            file_diffs.iter().all(|diff| !diff.has_changes)
+                                        }))
+                                    } else {
+                                        check_file_sync(
+                                            &order_dir,
+                                            file_entry,
+                                            &target,
+                                            order.global_ignore(),
+                                        )
+                                    };
                                     let diff_col = match sync {
-                                        Some(true) => style(format!("{:<diff_w$}", "\u{2713}"))
+                                        Ok(Some(true)) => style(format!("{:<diff_w$}", "\u{2713}"))
                                             .green()
                                             .to_string(),
-                                        Some(false) => style(format!("{:<diff_w$}", "\u{2260}"))
-                                            .yellow()
-                                            .to_string(),
-                                        None => style(format!("{:<diff_w$}", "\u{00b7}"))
+                                        Ok(Some(false)) => {
+                                            style(format!("{:<diff_w$}", "\u{2260}"))
+                                                .yellow()
+                                                .to_string()
+                                        }
+                                        Ok(None) => style(format!("{:<diff_w$}", "\u{00b7}"))
                                             .dim()
                                             .to_string(),
+                                        Err(error) => {
+                                            row_error = Some(format!(
+                                                "could not compare target content: {error}"
+                                            ));
+                                            style(format!("{:<diff_w$}", "\u{00b7}"))
+                                                .dim()
+                                                .to_string()
+                                        }
                                     };
-                                    (
+                                    let status = if row_error.is_some() {
+                                        style(format!("{:<status_w$}", "error")).red().to_string()
+                                    } else {
                                         style(format!("{:<status_w$}", "deployed"))
                                             .green()
-                                            .to_string(),
-                                        diff_col,
-                                    )
+                                            .to_string()
+                                    };
+                                    (status, diff_col)
                                 }
                             } else {
                                 (
@@ -222,6 +305,12 @@ pub fn cmd_status(ctx: &Context) -> anyhow::Result<()> {
                                 format!("~{}", &target_str[home_str.len()..])
                             } else {
                                 target_str.into_owned()
+                            };
+
+                            let target_display = if let Some(error) = row_error {
+                                format!("{target_display} ({error})")
+                            } else {
+                                target_display
                             };
 
                             rows.push(format!(

--- a/blend/src/commands/sync.rs
+++ b/blend/src/commands/sync.rs
@@ -1,12 +1,11 @@
-use crate::commands::helpers::{
-    compute_diff_for_result, only_structural_symlink_changes, target_is_unexpected_symlink,
-};
+use crate::commands::helpers::{compute_diff_for_result, result_has_type_mismatch};
 use crate::compose::{
     self, BuildResult, build_glob_set, collect_merged_files, discover_orders, write_result,
 };
 use crate::context::Context;
 use crate::diff::{diff_configs_with_base, key_change_with_base_display, semantic_diff_keys};
 use crate::formats::get_renderer;
+use crate::fs_node::node_kind;
 use crate::nickel;
 use crate::nickel::generated;
 use crate::nickel::key_path::KeyPath;
@@ -77,42 +76,19 @@ pub fn cmd_sync(
 
     for (order_name, results) in &built {
         for (result, file_entry_index) in results {
-            // Symlink entries: ensure the symlink exists and points to the right place
-            if result.is_symlink {
-                let needs_update = match std::fs::read_link(&result.target) {
-                    Ok(existing) => result.canonical_source.as_deref() != Some(existing.as_path()),
-                    Err(_) => true, // not a symlink or doesn't exist
-                };
-
-                if needs_update {
-                    match write_result(result, ctx.dry_run) {
-                        Ok(()) => {
-                            if !ctx.dry_run {
-                                log::success(&format!(
-                                    "Linked {}:{} -> {}",
-                                    order_name,
-                                    result.name,
-                                    result.target.display()
-                                ));
-                                source_to_target += 1;
-                            }
-                        }
-                        Err(e) => {
-                            log::error(&format!(
-                                "Failed to link {}:{}: {}",
-                                order_name, result.name, e
-                            ));
-                            build_errors += 1;
-                        }
-                    }
-                } else if ctx.verbose {
-                    log::info(&format!("{}:{} already linked", order_name, result.name));
-                }
-                continue;
-            }
-
             // New target file — always apply Source -> Target.
-            if !result.target.exists() {
+            let target_kind = match node_kind(&result.target) {
+                Ok(kind) => kind,
+                Err(error) => {
+                    log::error(&format!(
+                        "Failed to inspect target for {}:{}: {}",
+                        order_name, result.name, error
+                    ));
+                    build_errors += 1;
+                    continue;
+                }
+            };
+            if target_kind.is_none() {
                 let snapshot = ctx
                     .state
                     .read(order_name, &result.target)
@@ -163,43 +139,30 @@ pub fn cmd_sync(
             }
 
             // Compute diff
-            let diff_result = compute_diff_for_result(result);
-
-            // Auto-redeploy when Source -> Target will only change file types (replace
-            // unexpected symlinks with real files), no content edits. Two
-            // shapes: top-level symlink with matching content, OR a
-            // directory entry whose only drift is inner-file symlinks.
-            let top_level_symlink = !diff_result.has_changes
-                && target_is_unexpected_symlink(&result.target, result.is_symlink);
-            let inner_symlink_only = only_structural_symlink_changes(result);
-
-            if top_level_symlink || inner_symlink_only {
-                if ctx.dry_run {
-                    log::info_important(&format!(
-                        "[dry-run] {}:{} content matches but target is a symlink — would re-deploy",
-                        order_name, result.name
+            let diff_result = match compute_diff_for_result(result) {
+                Ok(diff) => diff,
+                Err(error) => {
+                    log::error(&format!(
+                        "Failed to compare target for {}:{}: {}",
+                        order_name, result.name, error
                     ));
-                } else {
-                    match write_result(result, false) {
-                        Ok(()) => {
-                            log::success(&format!(
-                                "Re-deployed {}:{} (replaced symlink with real file/directory)",
-                                order_name, result.name
-                            ));
-                            source_to_target += 1;
-                            refresh_snapshot_for_result(ctx, order_name, result);
-                        }
-                        Err(e) => {
-                            log::error(&format!(
-                                "Failed to re-deploy {}:{}: {}",
-                                order_name, result.name, e
-                            ));
-                            build_errors += 1;
-                        }
-                    }
+                    build_errors += 1;
+                    continue;
                 }
-                continue;
-            }
+            };
+
+            let has_type_mismatch = match result_has_type_mismatch(result) {
+                Ok(mismatch) => mismatch,
+                Err(error) => {
+                    log::error(&format!(
+                        "Failed to compare target for {}:{}: {}",
+                        order_name, result.name, error
+                    ));
+                    build_errors += 1;
+                    continue;
+                }
+            };
+            let structural_mismatch = result.is_symlink || has_type_mismatch;
 
             if !diff_result.has_changes {
                 if !ctx.dry_run {
@@ -212,7 +175,9 @@ pub fn cmd_sync(
             }
 
             // Determine if Target -> Source is possible for this entry.
-            let can_pull = !no_rewrite && can_auto_pull(ctx, order_name, result, *file_entry_index);
+            let can_pull = !structural_mismatch
+                && !no_rewrite
+                && can_auto_pull(ctx, order_name, result, *file_entry_index);
 
             // For from_config entries in interactive mode, use per-key flow
             let is_from_config = !result.is_plaintext && !result.is_symlink;
@@ -508,7 +473,11 @@ pub fn cmd_sync(
                         ));
                         None
                     });
-                let diff_with_base = compute_diff_with_base_for_result(result, snapshot.as_deref());
+                let diff_with_base = compute_diff_with_base_for_result(
+                    result,
+                    snapshot.as_deref(),
+                    structural_mismatch,
+                );
                 let prompt_diff = diff_with_base.as_ref().unwrap_or(&diff_result);
 
                 // Display the diff
@@ -527,9 +496,14 @@ pub fn cmd_sync(
                         if can_pull {
                             SyncAction::ApplyTargetToSource
                         } else {
+                            let reason = if structural_mismatch {
+                                "target structure does not match Source"
+                            } else {
+                                "from_config contains logic"
+                            };
                             log::warn(&format!(
-                                "Cannot apply target to source for {}:{} (from_config contains logic), skipping",
-                                order_name, result.name
+                                "Cannot apply Target -> Source for {}:{} ({}), skipping",
+                                order_name, result.name, reason
                             ));
                             SyncAction::Skip
                         }
@@ -544,12 +518,17 @@ pub fn cmd_sync(
                             log::info_important(&format!("[dry-run] would prompt{}", pull_note));
                             SyncAction::Skip
                         } else {
-                            let deployed_bytes = std::fs::read(&result.target).unwrap_or_default();
-                            let annotation = sync::compute_file_annotation(
-                                snapshot.as_deref(),
-                                result.content.as_bytes(),
-                                &deployed_bytes,
-                            );
+                            let annotation = if structural_mismatch {
+                                None
+                            } else {
+                                let deployed_bytes =
+                                    std::fs::read(&result.target).unwrap_or_default();
+                                sync::compute_file_annotation(
+                                    snapshot.as_deref(),
+                                    result.content.as_bytes(),
+                                    &deployed_bytes,
+                                )
+                            };
                             prompter.ask_sync_action(
                                 order_name,
                                 &result.name,
@@ -694,10 +673,11 @@ pub fn cmd_sync(
 fn compute_diff_with_base_for_result(
     result: &BuildResult,
     snapshot: Option<&[u8]>,
+    structural_mismatch: bool,
 ) -> Option<crate::diff::DiffResult> {
     let base = std::str::from_utf8(snapshot?).ok()?;
 
-    if result.is_symlink || !result.target.exists() {
+    if structural_mismatch {
         return None;
     }
 

--- a/blend/src/commands/view.rs
+++ b/blend/src/commands/view.rs
@@ -1,10 +1,12 @@
+use anyhow::Context as _;
 use console::style;
 
 use crate::commands::helpers::{
-    compute_diff_for_result, compute_dir_file_diffs, target_is_unexpected_symlink,
+    compute_diff_for_result, compute_dir_file_diffs, target_type_mismatch,
 };
 use crate::compose::{build_order, discover_orders};
 use crate::context::Context;
+use crate::fs_node::{NodeKind, node_kind};
 use crate::nickel::generated;
 use crate::output::log;
 
@@ -60,6 +62,9 @@ pub fn cmd_view(
                 println!("\n{}", style(order_name).cyan().bold());
 
                 for result in &results {
+                    let target_kind = node_kind(&result.target).with_context(|| {
+                        format!("could not inspect target {}", result.target.display())
+                    })?;
                     let target_display = shorten_path(&result.target);
                     let immutable_tag = if result.immutable {
                         format!(" {}", style("(immutable)").magenta())
@@ -71,16 +76,34 @@ pub fn cmd_view(
 
                     if result.is_symlink {
                         if let Some(canonical) = &result.canonical_source {
-                            let link_status = match std::fs::read_link(&result.target) {
-                                Ok(existing) if existing == *canonical => {
-                                    if short {
-                                        continue;
+                            let link_status =
+                                match (target_kind, std::fs::read_link(&result.target)) {
+                                    (Some(NodeKind::Symlink), Ok(existing))
+                                        if existing == *canonical =>
+                                    {
+                                        if short {
+                                            continue;
+                                        }
+                                        style("(linked)").green().to_string()
                                     }
-                                    style("(linked)").green().to_string()
-                                }
-                                Ok(_) => style("(wrong target)").yellow().to_string(),
-                                Err(_) => style("(not linked)").yellow().to_string(),
-                            };
+                                    (Some(NodeKind::Symlink), Ok(_)) => {
+                                        style("(wrong target)").yellow().to_string()
+                                    }
+                                    (Some(NodeKind::Symlink), Err(error)) => {
+                                        return Err(error).with_context(|| {
+                                            format!(
+                                                "could not read target symlink {}",
+                                                result.target.display()
+                                            )
+                                        });
+                                    }
+                                    (Some(actual), _) => style(format!(
+                                        "(type mismatch: expected symlink, found {actual})"
+                                    ))
+                                    .yellow()
+                                    .to_string(),
+                                    (None, _) => style("(not linked)").yellow().to_string(),
+                                };
                             println!(
                                 "{} {} {}",
                                 file_header,
@@ -102,21 +125,28 @@ pub fn cmd_view(
                             }
 
                             if show_diff && is_dir {
-                                // Enumerate per-file status for directories
-                                let file_diffs = compute_dir_file_diffs(result);
+                                let target_missing = target_kind.is_none();
+                                let direct_mismatch = target_type_mismatch(result)?;
+                                // Enumerate per-node status only when the target
+                                // root has the expected directory type.
+                                let file_diffs = if direct_mismatch.is_none() {
+                                    compute_dir_file_diffs(result)?
+                                } else {
+                                    Vec::new()
+                                };
                                 let any_file_changes = file_diffs.iter().any(|f| f.has_changes);
 
-                                if !result.target.exists() {
+                                if target_missing {
                                     annotations.push(style("(not deployed)").yellow().to_string());
                                     println!("{} {}", file_header, annotations.join(" "));
                                     has_changes = true;
-                                } else if target_is_unexpected_symlink(
-                                    &result.target,
-                                    result.is_symlink,
-                                ) && !any_file_changes
-                                {
+                                } else if let Some((expected, actual)) = direct_mismatch {
                                     annotations.push(
-                                        style("(symlinked, needs re-deploy)").yellow().to_string(),
+                                        style(format!(
+                                            "(type mismatch: expected {expected}, found {actual})"
+                                        ))
+                                        .yellow()
+                                        .to_string(),
                                     );
                                     println!("{} {}", file_header, annotations.join(" "));
                                     has_changes = true;
@@ -142,15 +172,13 @@ pub fn cmd_view(
                                             );
                                             has_changes = true;
                                         } else if f.has_changes {
-                                            let label = if f.target_is_symlink {
-                                                if f.diff_output.is_empty() {
-                                                    format!("{} (unexpected symlink)", rel)
-                                                } else {
-                                                    format!(
-                                                        "{} (unexpected symlink, modified)",
-                                                        rel
-                                                    )
-                                                }
+                                            let label = if let Some(target_kind) = f.target_kind
+                                                && target_kind != f.expected_kind
+                                            {
+                                                format!(
+                                                    "{} (type mismatch: expected {}, found {})",
+                                                    rel, f.expected_kind, target_kind
+                                                )
                                             } else {
                                                 format!("{}", rel)
                                             };
@@ -174,12 +202,15 @@ pub fn cmd_view(
                                     }
                                 }
                             } else if show_diff && !is_dir {
-                                let diff_result = compute_diff_for_result(result);
-                                let unexpected_sym =
-                                    target_is_unexpected_symlink(&result.target, result.is_symlink);
-                                if unexpected_sym {
+                                let diff_result = compute_diff_for_result(result)?;
+                                let direct_mismatch = target_type_mismatch(result)?;
+                                if let Some((expected, actual)) = direct_mismatch {
                                     annotations.push(
-                                        style("(symlinked, needs re-deploy)").yellow().to_string(),
+                                        style(format!(
+                                            "(type mismatch: expected {expected}, found {actual})"
+                                        ))
+                                        .yellow()
+                                        .to_string(),
                                     );
                                 }
                                 if diff_result.has_changes {
@@ -192,11 +223,11 @@ pub fn cmd_view(
                                         println!("    {}", line);
                                     }
                                     has_changes = true;
-                                } else if !result.target.exists() {
+                                } else if target_kind.is_none() {
                                     annotations.push(style("(not deployed)").yellow().to_string());
                                     println!("{} {}", file_header, annotations.join(" "));
                                     has_changes = true;
-                                } else if unexpected_sym {
+                                } else if direct_mismatch.is_some() {
                                     println!("{} {}", file_header, annotations.join(" "));
                                     has_changes = true;
                                 } else if !short {
@@ -214,12 +245,13 @@ pub fn cmd_view(
 
                     // Structured config
                     let diff_status = if show_diff {
-                        Some(compute_diff_for_result(result))
+                        Some(compute_diff_for_result(result)?)
                     } else {
                         None
                     };
 
-                    let target_missing = !result.target.exists();
+                    let target_missing = target_kind.is_none();
+                    let direct_mismatch = target_type_mismatch(result)?;
                     let has_diff_output = diff_status
                         .as_ref()
                         .is_some_and(|diff_result| diff_result.has_changes);
@@ -248,11 +280,14 @@ pub fn cmd_view(
                             }
                             has_changes = true;
                         }
-                    } else if target_is_unexpected_symlink(&result.target, result.is_symlink) {
+                    } else if let Some((expected, actual)) = direct_mismatch {
                         println!(
                             "{} {}",
                             file_header,
-                            style("(symlinked, needs re-deploy)").yellow()
+                            style(format!(
+                                "(type mismatch: expected {expected}, found {actual})"
+                            ))
+                            .yellow()
                         );
                         has_changes = true;
                     } else if !short {

--- a/blend/src/compose.rs
+++ b/blend/src/compose.rs
@@ -7,6 +7,7 @@ use walkdir::WalkDir;
 
 use crate::context::Context;
 use crate::formats::get_renderer;
+use crate::fs_node::{NodeKind, node_kind};
 use crate::immutable;
 use crate::nickel::{FileEntry, Format, NickelEvaluator, Order};
 use crate::output::log;
@@ -230,53 +231,47 @@ fn build_file_entry(
     ))
 }
 
-/// If the target path is a symlink, remove it so we write a regular file
-/// instead of writing through the symlink to its target.
-/// Ensure a directory exists at the given path, removing any symlink that blocks it.
-///
-/// Walks up from the target path to find any path component that is a symlink
-/// (broken or otherwise) and removes it before calling `create_dir_all`.
-/// This handles the case where previous deployments left behind symlinks
-/// at directories that blend now needs to create as real directories.
 fn ensure_dir(path: &Path) -> Result<()> {
-    for ancestor in path.ancestors() {
-        if ancestor == Path::new("") || ancestor == Path::new("/") {
-            break;
-        }
-        match std::fs::symlink_metadata(ancestor) {
-            Ok(meta) if meta.file_type().is_symlink() => {
-                std::fs::remove_file(ancestor).with_context(|| {
-                    format!(
-                        "Failed to remove symlink blocking directory creation: {}",
-                        ancestor.display()
-                    )
-                })?;
-                break;
-            }
-            Ok(_) => {
-                break;
-            }
-            Err(_) => {
-                continue;
-            }
-        }
-    }
     std::fs::create_dir_all(path)
         .with_context(|| format!("Failed to create directory {}", path.display()))?;
     Ok(())
 }
 
-fn remove_symlink_if_exists(path: &Path, dry_run: bool) -> Result<()> {
-    match std::fs::symlink_metadata(path) {
-        Ok(meta) if meta.file_type().is_symlink() => {
-            if dry_run {
-                log::info(&format!("Would remove symlink {}", path.display()));
-                return Ok(());
-            }
-            std::fs::remove_file(path)
-                .with_context(|| format!("Failed to remove symlink {}", path.display()))?;
+fn remove_exact_node(path: &Path, dry_run: bool) -> Result<()> {
+    let Some(kind) = node_kind(path)? else {
+        return Ok(());
+    };
+    if dry_run {
+        log::info(&format!("Would remove {kind} {}", path.display()));
+        return Ok(());
+    }
+    if kind == NodeKind::Directory {
+        std::fs::remove_dir_all(path)
+            .with_context(|| format!("Failed to remove directory {}", path.display()))?;
+    } else {
+        std::fs::remove_file(path)
+            .with_context(|| format!("Failed to remove {kind} {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn prepare_exact_node(path: &Path, expected: NodeKind, dry_run: bool) -> Result<()> {
+    if let Some(actual) = node_kind(path)?
+        && actual != expected
+    {
+        remove_exact_node(path, dry_run)?;
+    }
+    Ok(())
+}
+
+fn prepare_managed_parent_dirs(root: &Path, relative: &Path, dry_run: bool) -> Result<()> {
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        current.push(component);
+        prepare_exact_node(&current, NodeKind::Directory, dry_run)?;
+        if !dry_run {
+            ensure_dir(&current)?;
         }
-        _ => {}
     }
     Ok(())
 }
@@ -316,12 +311,6 @@ fn remove_immutable_flag_recursive(dir: &Path, warn_on_failure: bool) -> Result<
     Ok(())
 }
 
-fn target_is_real_dir(path: &Path) -> bool {
-    std::fs::symlink_metadata(path)
-        .map(|meta| meta.is_dir() && !meta.file_type().is_symlink())
-        .unwrap_or(false)
-}
-
 /// Write build result to target
 pub fn write_result(result: &BuildResult, dry_run: bool) -> Result<()> {
     if result.is_symlink {
@@ -342,7 +331,8 @@ pub fn write_result(result: &BuildResult, dry_run: bool) -> Result<()> {
             .as_ref()
             .is_some_and(|source_path| source_path.is_dir());
 
-    if result.target.exists() && !is_plaintext_dir {
+    let existing_kind = node_kind(&result.target)?;
+    if existing_kind.is_some() && !is_plaintext_dir {
         if dry_run {
             if result.immutable {
                 log::info(&format!(
@@ -350,9 +340,9 @@ pub fn write_result(result: &BuildResult, dry_run: bool) -> Result<()> {
                     result.target.display()
                 ));
             }
-        } else if target_is_real_dir(&result.target) {
+        } else if existing_kind == Some(NodeKind::Directory) {
             remove_immutable_flag_recursive(&result.target, result.immutable)?;
-        } else {
+        } else if existing_kind == Some(NodeKind::File) {
             remove_immutable_flag(&result.target, result.immutable)?;
         }
     }
@@ -375,7 +365,7 @@ pub fn write_result(result: &BuildResult, dry_run: bool) -> Result<()> {
         }
     } else {
         if dry_run {
-            remove_symlink_if_exists(&result.target, true)?;
+            prepare_exact_node(&result.target, NodeKind::File, true)?;
             log::info(&format!("Would write to {}", result.target.display()));
             if result.immutable {
                 log::info(&format!(
@@ -391,7 +381,7 @@ pub fn write_result(result: &BuildResult, dry_run: bool) -> Result<()> {
             ensure_dir(parent)?;
         }
 
-        remove_symlink_if_exists(&result.target, false)?;
+        prepare_exact_node(&result.target, NodeKind::File, false)?;
         std::fs::write(&result.target, &result.content)
             .with_context(|| format!("Failed to write {}", result.target.display()))?;
     }
@@ -410,6 +400,7 @@ pub fn write_result(result: &BuildResult, dry_run: bool) -> Result<()> {
 
 /// Create a symlink at target pointing to source
 fn create_symlink(source: &Path, target: &Path, dry_run: bool) -> Result<()> {
+    remove_exact_node(target, dry_run)?;
     if dry_run {
         log::info(&format!(
             "Would symlink {} -> {}",
@@ -422,17 +413,6 @@ fn create_symlink(source: &Path, target: &Path, dry_run: bool) -> Result<()> {
     // Ensure parent directory exists
     if let Some(parent) = target.parent() {
         ensure_dir(parent)?;
-    }
-
-    // Remove existing file, symlink, or directory at target
-    if let Ok(meta) = std::fs::symlink_metadata(target) {
-        if meta.is_dir() && !meta.file_type().is_symlink() {
-            std::fs::remove_dir_all(target)
-                .with_context(|| format!("Failed to remove directory {}", target.display()))?;
-        } else {
-            std::fs::remove_file(target)
-                .with_context(|| format!("Failed to remove {}", target.display()))?;
-        }
     }
 
     #[cfg(unix)]
@@ -455,7 +435,7 @@ fn create_symlink(source: &Path, target: &Path, dry_run: bool) -> Result<()> {
 /// Copy a single file to target
 fn copy_file(source: &Path, target: &Path, dry_run: bool) -> Result<()> {
     if dry_run {
-        remove_symlink_if_exists(target, true)?;
+        prepare_exact_node(target, NodeKind::File, true)?;
         log::info(&format!(
             "Would copy {} to {}",
             source.display(),
@@ -469,7 +449,7 @@ fn copy_file(source: &Path, target: &Path, dry_run: bool) -> Result<()> {
         ensure_dir(parent)?;
     }
 
-    remove_symlink_if_exists(target, false)?;
+    prepare_exact_node(target, NodeKind::File, false)?;
     std::fs::copy(source, target).with_context(|| {
         format!(
             "Failed to copy {} to {}",
@@ -593,8 +573,10 @@ fn copy_directory(
         ));
     }
 
-    // If the top-level target is a symlink, remove it first
-    remove_symlink_if_exists(target, dry_run)?;
+    prepare_exact_node(target, NodeKind::Directory, dry_run)?;
+    if !dry_run {
+        ensure_dir(target)?;
+    }
 
     let merged = collect_merged_files(source, local_dir, exclude)?;
 
@@ -611,13 +593,13 @@ fn copy_directory(
             continue;
         }
 
-        if let Some(parent) = target_path.parent() {
-            ensure_dir(parent)?;
+        if let Some(relative_parent) = mf.rel_path.parent() {
+            prepare_managed_parent_dirs(target, relative_parent, false)?;
         }
-        if target_path.exists() {
+        if node_kind(&target_path)? == Some(NodeKind::File) {
             remove_immutable_flag(&target_path, immutable)?;
         }
-        remove_symlink_if_exists(&target_path, false)?;
+        prepare_exact_node(&target_path, NodeKind::File, false)?;
         std::fs::copy(&mf.source, &target_path)?;
         if immutable {
             set_immutable_flag(&target_path)?;
@@ -867,6 +849,71 @@ mod tests {
             std::fs::read_to_string(target.join("extra.txt")).unwrap(),
             "local-only"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_write_result_preserves_symlinked_ancestor() {
+        let temp = TempDir::new().unwrap();
+        let backing = temp.path().join("backing");
+        let linked_parent = temp.path().join("linked-parent");
+        std::fs::create_dir_all(&backing).unwrap();
+        std::os::unix::fs::symlink(&backing, &linked_parent).unwrap();
+
+        let result = BuildResult {
+            target: linked_parent.join("config.txt"),
+            content: "new content\n".to_string(),
+            is_plaintext: false,
+            source_path: None,
+            name: "config.txt".to_string(),
+            format: Format::Plaintext,
+            ignore_keys: vec![],
+            is_symlink: false,
+            canonical_source: None,
+            exclude_patterns: vec![],
+            local_dir: None,
+            immutable: false,
+        };
+
+        write_result(&result, false).unwrap();
+        assert!(
+            linked_parent
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            std::fs::read_to_string(backing.join("config.txt")).unwrap(),
+            "new content\n"
+        );
+    }
+
+    #[test]
+    fn test_write_result_replaces_exact_directory_with_file() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("config.txt");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("old.txt"), "old").unwrap();
+
+        let result = BuildResult {
+            target: target.clone(),
+            content: "new content\n".to_string(),
+            is_plaintext: false,
+            source_path: None,
+            name: "config.txt".to_string(),
+            format: Format::Plaintext,
+            ignore_keys: vec![],
+            is_symlink: false,
+            canonical_source: None,
+            exclude_patterns: vec![],
+            local_dir: None,
+            immutable: false,
+        };
+
+        write_result(&result, false).unwrap();
+        assert_eq!(node_kind(&target).unwrap(), Some(NodeKind::File));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new content\n");
     }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/blend/src/diff.rs
+++ b/blend/src/diff.rs
@@ -7,11 +7,13 @@ pub use semantic::{
 };
 pub use text::{text_diff, text_diff_with_base};
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use walkdir::WalkDir;
 
 use crate::formats::get_renderer;
+use crate::fs_node::{NodeKind, node_kind};
 use crate::nickel::{FileEntry, Format};
 
 /// Result of comparing two configs
@@ -50,10 +52,17 @@ pub struct FileDiffResult {
     pub diff_output: String,
     /// Whether the file only exists in the source (not yet deployed)
     pub source_only: bool,
-    /// Whether the deployed target is a symlink. Set even when resolved
-    /// content matches the source, so callers can flag unexpected symlinks
-    /// that need to be replaced with a real file on the next sync.
-    pub target_is_symlink: bool,
+    /// Expected type for this managed node.
+    pub expected_kind: NodeKind,
+    /// Deployed node type, observed without following the final component.
+    pub target_kind: Option<NodeKind>,
+}
+
+impl FileDiffResult {
+    pub fn has_type_mismatch(&self) -> bool {
+        self.target_kind
+            .is_some_and(|target_kind| target_kind != self.expected_kind)
+    }
 }
 
 /// Enumerate files in the source directory and compare each against the target.
@@ -65,58 +74,112 @@ pub fn diff_directory(
     source_dir: &Path,
     target_dir: &Path,
     ignore_patterns: &[String],
-) -> Vec<FileDiffResult> {
-    let mut results = Vec::new();
-
+) -> std::io::Result<Vec<FileDiffResult>> {
     if !source_dir.is_dir() {
-        return results;
+        return Ok(Vec::new());
     }
 
+    let mut managed_files = Vec::new();
     for entry in WalkDir::new(source_dir).min_depth(1).sort_by_file_name() {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
+        let entry = entry.map_err(std::io::Error::other)?;
         if entry.file_type().is_dir() {
             continue;
         }
-        let rel_path = match entry.path().strip_prefix(source_dir) {
-            Ok(r) => r.to_path_buf(),
-            Err(_) => continue,
-        };
+        let rel_path = entry
+            .path()
+            .strip_prefix(source_dir)
+            .map_err(std::io::Error::other)?
+            .to_path_buf();
+        managed_files.push((entry.path().to_path_buf(), rel_path));
+    }
 
+    diff_managed_files(&managed_files, target_dir, ignore_patterns)
+}
+
+/// Compare the exact file inventory Blend will deploy for a directory entry.
+/// Parent directories implied by each file are managed nodes too.
+pub fn diff_managed_files(
+    managed_files: &[(PathBuf, PathBuf)],
+    target_dir: &Path,
+    ignore_patterns: &[String],
+) -> std::io::Result<Vec<FileDiffResult>> {
+    let mut nodes: BTreeMap<PathBuf, (NodeKind, Option<&Path>)> = BTreeMap::new();
+    for (source, rel_path) in managed_files {
+        if let Some(parent) = rel_path.parent() {
+            let mut current = PathBuf::new();
+            for component in parent.components() {
+                current.push(component);
+                nodes
+                    .entry(current.clone())
+                    .or_insert((NodeKind::Directory, None));
+            }
+        }
+        nodes.insert(rel_path.clone(), (NodeKind::File, Some(source.as_path())));
+    }
+
+    let mut results = Vec::new();
+    let mut mismatched_directories = Vec::new();
+    for (rel_path, (expected_kind, source_path)) in nodes {
+        if mismatched_directories
+            .iter()
+            .any(|parent: &PathBuf| rel_path.starts_with(parent))
+        {
+            continue;
+        }
         let target_file = target_dir.join(&rel_path);
-        if !target_file.exists() {
+        let target_kind = node_kind(&target_file)?;
+
+        if target_kind.is_none() {
+            // Missing directories are created as needed while copying their
+            // managed children. Missing files are the actionable diff.
+            if expected_kind == NodeKind::Directory {
+                continue;
+            }
             results.push(FileDiffResult {
                 rel_path,
                 has_changes: true,
                 diff_output: String::new(),
                 source_only: true,
-                target_is_symlink: false,
+                expected_kind,
+                target_kind,
             });
             continue;
         }
 
-        // Inspect the target file type without following symlinks. A target
-        // that is a symlink is structurally wrong (orders deploy real files)
-        // and must be flagged for redeploy regardless of resolved content.
-        let target_is_symlink = std::fs::symlink_metadata(&target_file)
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false);
+        if target_kind != Some(expected_kind) {
+            if expected_kind == NodeKind::Directory {
+                mismatched_directories.push(rel_path.clone());
+            }
+            results.push(FileDiffResult {
+                rel_path,
+                has_changes: true,
+                diff_output: String::new(),
+                source_only: false,
+                expected_kind,
+                target_kind,
+            });
+            continue;
+        }
+
+        if expected_kind == NodeKind::Directory {
+            continue;
+        }
 
         // Both exist: compare contents
-        let source_content = match std::fs::read_to_string(entry.path()) {
+        let source_path = source_path.expect("file nodes have a source path");
+        let source_content = match std::fs::read_to_string(source_path) {
             Ok(c) => c,
             Err(_) => {
                 // Binary file — compare raw bytes
-                let source_bytes = std::fs::read(entry.path()).unwrap_or_default();
+                let source_bytes = std::fs::read(source_path).unwrap_or_default();
                 let target_bytes = std::fs::read(&target_file).unwrap_or_default();
                 results.push(FileDiffResult {
                     rel_path,
-                    has_changes: target_is_symlink || source_bytes != target_bytes,
+                    has_changes: source_bytes != target_bytes,
                     diff_output: String::new(),
                     source_only: false,
-                    target_is_symlink,
+                    expected_kind,
+                    target_kind,
                 });
                 continue;
             }
@@ -130,7 +193,8 @@ pub fn diff_directory(
                     has_changes: true,
                     diff_output: String::new(),
                     source_only: false,
-                    target_is_symlink,
+                    expected_kind,
+                    target_kind,
                 });
                 continue;
             }
@@ -139,14 +203,15 @@ pub fn diff_directory(
         let diff = text_diff(&source_content, &target_content, ignore_patterns);
         results.push(FileDiffResult {
             rel_path,
-            has_changes: target_is_symlink || diff.has_changes,
+            has_changes: diff.has_changes,
             diff_output: diff.output,
             source_only: false,
-            target_is_symlink,
+            expected_kind,
+            target_kind,
         });
     }
 
-    results
+    Ok(results)
 }
 
 /// Check whether a deployed target file is in sync with its source.
@@ -160,13 +225,13 @@ pub fn check_file_sync(
     file_entry: &FileEntry,
     target: &Path,
     global_ignore: &[String],
-) -> Option<bool> {
+) -> std::io::Result<Option<bool>> {
     if file_entry.symlink {
-        return None; // Symlinks are checked separately in cmd_status
+        return Ok(None); // Symlinks are checked separately in cmd_status
     }
 
     if !target.exists() {
-        return None;
+        return Ok(None);
     }
 
     let mut ignore_keys: Vec<String> = global_ignore.to_vec();
@@ -177,30 +242,32 @@ pub fn check_file_sync(
         let source_path = order_dir.join(file);
         if source_path.is_dir() {
             // For directories, check all files within
-            let file_diffs = diff_directory(&source_path, target, &ignore_keys);
+            let file_diffs = diff_directory(&source_path, target, &ignore_keys)?;
             if file_diffs.is_empty() {
-                return None;
+                return Ok(None);
             }
             let all_in_sync = file_diffs.iter().all(|f| !f.has_changes);
-            return Some(all_in_sync);
+            return Ok(Some(all_in_sync));
         }
-        let source_content = std::fs::read_to_string(&source_path).ok()?;
-        let deployed = std::fs::read_to_string(target).ok()?;
+        let source_content = std::fs::read_to_string(&source_path)?;
+        let deployed = std::fs::read_to_string(target)?;
         let result = diff_configs(Format::Plaintext, &source_content, &deployed, &ignore_keys);
-        return Some(!result.has_changes);
+        return Ok(Some(!result.has_changes));
     }
 
-    let deployed = std::fs::read_to_string(target).ok()?;
+    let deployed = std::fs::read_to_string(target)?;
 
     if let Some(config) = &file_entry.from_config {
         // Structured config rendered from nickel
         let format = file_entry.effective_format();
-        let rendered = get_renderer(format).render(config).ok()?;
+        let rendered = get_renderer(format)
+            .render(config)
+            .map_err(std::io::Error::other)?;
         let result = diff_configs(format, &rendered, &deployed, &ignore_keys);
-        return Some(!result.has_changes);
+        return Ok(Some(!result.has_changes));
     }
 
-    None
+    Ok(None)
 }
 
 /// Diff two configs based on format
@@ -265,7 +332,7 @@ mod tests {
         write_file(source.path(), "b.txt", "world\n");
         write_file(target.path(), "a.txt", "hello\n");
         write_file(target.path(), "b.txt", "world\n");
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 2);
         for r in &results {
             assert!(!r.has_changes);
@@ -280,7 +347,7 @@ mod tests {
         write_file(source.path(), "only_in_source.txt", "data\n");
         write_file(source.path(), "shared.txt", "same\n");
         write_file(target.path(), "shared.txt", "same\n");
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 2);
         let source_only = results
             .iter()
@@ -299,7 +366,7 @@ mod tests {
         write_file(source.path(), "shared.txt", "same\n");
         write_file(target.path(), "shared.txt", "same\n");
         write_file(target.path(), "only_in_target.txt", "extra\n");
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].rel_path.as_path(), Path::new("shared.txt"));
         assert!(!results[0].has_changes);
@@ -311,7 +378,7 @@ mod tests {
         let target = TempDir::new().unwrap();
         write_file(source.path(), "config.txt", "key=new_value\n");
         write_file(target.path(), "config.txt", "key=old_value\n");
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].has_changes);
         assert!(!results[0].diff_output.is_empty());
@@ -325,7 +392,7 @@ mod tests {
         write_file(source.path(), "a/d.txt", "shallow\n");
         write_file(target.path(), "a/b/c.txt", "deep\n");
         write_file(target.path(), "a/d.txt", "different\n");
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 2);
         let deep = results
             .iter()
@@ -340,12 +407,26 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_directory_stops_below_known_directory_type_mismatch() {
+        let source = TempDir::new().unwrap();
+        let target = TempDir::new().unwrap();
+        write_file(source.path(), "nested/config", "managed\n");
+        write_file(target.path(), "nested", "not a directory\n");
+
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].rel_path, Path::new("nested"));
+        assert_eq!(results[0].expected_kind, NodeKind::Directory);
+        assert_eq!(results[0].target_kind, Some(NodeKind::File));
+    }
+
+    #[test]
     fn test_diff_directory_empty_directories() {
         let source = TempDir::new().unwrap();
         let target = TempDir::new().unwrap();
         std::fs::create_dir_all(source.path().join("empty_sub")).unwrap();
         std::fs::create_dir_all(target.path().join("empty_sub")).unwrap();
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert!(results.is_empty());
     }
 
@@ -355,7 +436,7 @@ mod tests {
         let target = TempDir::new().unwrap();
         std::fs::write(source.path().join("image.bin"), [0x00, 0xFF, 0x80, 0x01]).unwrap();
         std::fs::write(target.path().join("image.bin"), [0x00, 0xFF, 0x80, 0x02]).unwrap();
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].has_changes);
         assert!(results[0].diff_output.is_empty());
@@ -368,7 +449,7 @@ mod tests {
         let bytes = [0x00, 0xFF, 0x80, 0x01];
         std::fs::write(source.path().join("data.bin"), bytes).unwrap();
         std::fs::write(target.path().join("data.bin"), bytes).unwrap();
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(!results[0].has_changes);
     }
@@ -379,9 +460,10 @@ mod tests {
         let target = TempDir::new().unwrap();
         write_file(source.path(), "conf", "stable=1\nvolatile=aaa\n");
         write_file(target.path(), "conf", "stable=1\nvolatile=zzz\n");
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert!(results[0].has_changes);
-        let results = diff_directory(source.path(), target.path(), &["^volatile".to_string()]);
+        let results =
+            diff_directory(source.path(), target.path(), &["^volatile".to_string()]).unwrap();
         assert!(!results[0].has_changes);
     }
 
@@ -392,7 +474,7 @@ mod tests {
         let target = TempDir::new().unwrap();
         write_file(target.path(), "a.txt", "hello\n");
         let fake_source = target.path().join("nonexistent");
-        let results = diff_directory(&fake_source, target.path(), &[]);
+        let results = diff_directory(&fake_source, target.path(), &[]).unwrap();
         assert!(results.is_empty());
     }
 
@@ -401,7 +483,7 @@ mod tests {
         let source = TempDir::new().unwrap();
         write_file(source.path(), "a.txt", "hello\n");
         let fake_target = source.path().join("nonexistent");
-        let results = diff_directory(source.path(), &fake_target, &[]);
+        let results = diff_directory(source.path(), &fake_target, &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].source_only);
     }
@@ -420,12 +502,11 @@ mod tests {
         std::os::unix::fs::symlink(backing.path().join("config"), target.path().join("config"))
             .unwrap();
 
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
-        assert!(
-            results[0].target_is_symlink,
-            "target file is a symlink — must be flagged"
-        );
+        assert_eq!(results[0].expected_kind, NodeKind::File);
+        assert_eq!(results[0].target_kind, Some(NodeKind::Symlink));
+        assert!(results[0].has_type_mismatch());
         assert!(
             results[0].has_changes,
             "symlink target must be reported as needing redeploy even if resolved content matches"
@@ -443,10 +524,12 @@ mod tests {
         std::os::unix::fs::symlink(backing.path().join("config"), target.path().join("config"))
             .unwrap();
 
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].target_is_symlink);
+        assert_eq!(results[0].target_kind, Some(NodeKind::Symlink));
+        assert!(results[0].has_type_mismatch());
         assert!(results[0].has_changes);
+        assert!(results[0].diff_output.is_empty());
     }
 
     #[cfg(unix)]
@@ -457,9 +540,10 @@ mod tests {
         write_file(source.path(), "config", "key=value\n");
         write_file(target.path(), "config", "key=value\n");
 
-        let results = diff_directory(source.path(), target.path(), &[]);
+        let results = diff_directory(source.path(), target.path(), &[]).unwrap();
         assert_eq!(results.len(), 1);
-        assert!(!results[0].target_is_symlink);
+        assert_eq!(results[0].target_kind, Some(NodeKind::File));
+        assert!(!results[0].has_type_mismatch());
         assert!(!results[0].has_changes);
     }
 }

--- a/blend/src/fs_node.rs
+++ b/blend/src/fs_node.rs
@@ -1,0 +1,80 @@
+use std::fmt;
+use std::io;
+use std::path::Path;
+
+/// Filesystem node type observed without following the final path component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    File,
+    Directory,
+    Symlink,
+    Other,
+}
+
+impl fmt::Display for NodeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::File => "file",
+            Self::Directory => "directory",
+            Self::Symlink => "symlink",
+            Self::Other => "other",
+        })
+    }
+}
+
+/// Return the kind of the exact path node, without following a final symlink.
+/// A dangling symlink is therefore present and reported as `Symlink`.
+pub fn node_kind(path: &Path) -> io::Result<Option<NodeKind>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            let kind = if file_type.is_symlink() {
+                NodeKind::Symlink
+            } else if file_type.is_file() {
+                NodeKind::File
+            } else if file_type.is_dir() {
+                NodeKind::Directory
+            } else {
+                NodeKind::Other
+            };
+            Ok(Some(kind))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn classifies_missing_file_and_directory_nodes() {
+        let temp = TempDir::new().unwrap();
+        assert_eq!(node_kind(&temp.path().join("missing")).unwrap(), None);
+
+        let file = temp.path().join("file");
+        std::fs::write(&file, "content").unwrap();
+        assert_eq!(node_kind(&file).unwrap(), Some(NodeKind::File));
+        assert_eq!(node_kind(temp.path()).unwrap(), Some(NodeKind::Directory));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classifies_broken_symlink_without_following_it() {
+        let temp = TempDir::new().unwrap();
+        let link = temp.path().join("link");
+        std::os::unix::fs::symlink("missing", &link).unwrap();
+        assert_eq!(node_kind(&link).unwrap(), Some(NodeKind::Symlink));
+    }
+
+    #[test]
+    fn does_not_treat_an_uninspectable_child_as_missing() {
+        let temp = TempDir::new().unwrap();
+        let parent = temp.path().join("parent");
+        std::fs::write(&parent, "not a directory").unwrap();
+
+        assert!(node_kind(&parent.join("child")).is_err());
+    }
+}

--- a/blend/src/main.rs
+++ b/blend/src/main.rs
@@ -4,6 +4,7 @@ mod compose;
 mod context;
 mod diff;
 mod formats;
+mod fs_node;
 mod immutable;
 mod metadata;
 mod migration;

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -1693,6 +1693,11 @@ fn create_symlink(target: &Path, link: &Path) {
     std::os::unix::fs::symlink(target, link).unwrap();
 }
 
+#[cfg(unix)]
+fn create_broken_symlink(link: &Path) {
+    create_symlink(Path::new("missing-target"), link);
+}
+
 /// Replace an existing file with an unexpected symlink to identical content.
 /// The returned TempDir keeps the backing file alive for the test duration.
 #[cfg(unix)]
@@ -1754,10 +1759,10 @@ fn test_sync_force_source_to_target_replaces_symlink_with_real_file() {
     // Content should still match
     assert_eq!(std::fs::read_to_string(&target).unwrap(), source_content);
 
-    // Output should mention re-deployment
+    // Output should report the explicit Source -> Target resolution.
     assert!(
-        stdout.contains("Re-deployed") || stdout.contains("replaced symlink"),
-        "Should mention re-deployment in output:\n{stdout}"
+        stdout.contains("Applied Source -> Target"),
+        "Should mention Source -> Target in output:\n{stdout}"
     );
 }
 
@@ -1809,8 +1814,8 @@ fn test_sync_force_source_to_target_replaces_structured_file_symlink() {
 #[test]
 #[cfg(unix)]
 fn test_view_shows_symlink_annotation() {
-    // When a target is a symlink but the order doesn't specify symlink=true,
-    // `blend view` should show a "(symlinked, needs re-deploy)" annotation.
+    // When a target is a symlink but the order expects a regular file,
+    // `blend view` should report a generic node-type mismatch.
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
 
@@ -1835,16 +1840,16 @@ fn test_view_shows_symlink_annotation() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        stdout.contains("symlinked, needs re-deploy"),
-        "Should show symlink annotation in view output:\n{stdout}"
+        stdout.contains("type mismatch: expected file, found symlink"),
+        "Should show type mismatch in view output:\n{stdout}"
     );
 }
 
 #[test]
 #[cfg(unix)]
-fn test_sync_interactive_replaces_symlink_automatically() {
-    // In interactive mode with no content changes, unexpected symlinks should
-    // be auto-redeployed without prompting.
+fn test_sync_interactive_does_not_replace_symlink_automatically() {
+    // An existing node-type mismatch requires an explicit Source -> Target
+    // decision even when the symlink referent has matching content.
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
 
@@ -1858,10 +1863,7 @@ fn test_sync_interactive_replaces_symlink_automatically() {
     let target = home.path().join(".config/plaintext-single/config.txt");
     let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
-    // Run sync without --force-source-to-target (interactive mode), but since there's no content
-    // diff, the symlink replacement should happen automatically without prompting.
-    // (No stdin needed because we don't reach the prompt.)
-    let output = run_blend(home.path(), &orders, &["sync", "plaintext-single"]);
+    let output = run_blend_with_stdin(home.path(), &orders, &["sync", "plaintext-single"], "k\n");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(
@@ -1871,10 +1873,10 @@ fn test_sync_interactive_replaces_symlink_automatically() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Should now be a real file
+    // Skip must preserve the exact target symlink.
     assert!(
-        !target.symlink_metadata().unwrap().file_type().is_symlink(),
-        "Target should no longer be a symlink after interactive sync"
+        target.symlink_metadata().unwrap().file_type().is_symlink(),
+        "Target symlink must remain after skipping the conflict"
     );
 }
 
@@ -1904,8 +1906,8 @@ fn test_sync_dry_run_detects_symlink_but_does_not_replace() {
 
     assert!(output.status.success());
     assert!(
-        stdout.contains("symlinked") || stdout.contains("re-deploy"),
-        "Dry run should mention symlink mismatch:\n{stdout}"
+        stdout.contains("type mismatch: expected file, found symlink"),
+        "Dry run should mention the type mismatch:\n{stdout}"
     );
 
     // Should still be a symlink
@@ -1915,9 +1917,310 @@ fn test_sync_dry_run_detects_symlink_but_does_not_replace() {
     );
 }
 
-/// Inner-file leftover scenario: the deployed *directory* is a real dir,
-/// but one file inside it is an unexpected symlink. Status, view, and
-/// sync must all surface and replace it — these were silent before.
+#[test]
+#[cfg(unix)]
+fn test_broken_symlink_is_existing_type_mismatch_and_requires_explicit_source() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("plaintext-single");
+    let target = home.path().join(".config/plaintext-single/config.txt");
+    create_broken_symlink(&target);
+
+    let status = run_blend(home.path(), blend_dir.path(), &[]);
+    let status_stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(status.status.success());
+    assert!(status_stdout.contains("mismatch"));
+    assert!(!status_stdout.contains("plaintext-single     config.txt           pending"));
+
+    let view = run_blend(home.path(), blend_dir.path(), &["view", "plaintext-single"]);
+    let view_stdout = String::from_utf8_lossy(&view.stdout);
+    assert!(view_stdout.contains("type mismatch: expected file, found symlink"));
+    assert!(!view_stdout.contains("not deployed"));
+
+    let source = orders_dir(blend_dir.path()).join("plaintext-single/config.txt");
+    let source_before = std::fs::read_to_string(&source).unwrap();
+    let pull = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-target-to-source", "plaintext-single"],
+    );
+    let pull_stdout = String::from_utf8_lossy(&pull.stdout);
+    assert!(pull.status.success());
+    assert!(pull_stdout.contains("target structure does not match Source"));
+    assert_eq!(std::fs::read_to_string(&source).unwrap(), source_before);
+    assert!(target.symlink_metadata().unwrap().file_type().is_symlink());
+
+    let push = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "plaintext-single"],
+    );
+    assert!(push.status.success());
+    assert!(!target.symlink_metadata().unwrap().file_type().is_symlink());
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), source_before);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_force_target_to_source_does_not_follow_unexpected_symlink() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("plaintext-single");
+    let source = orders_dir(blend_dir.path()).join("plaintext-single/config.txt");
+    let source_before = std::fs::read_to_string(&source).unwrap();
+    let backing = TempDir::new().unwrap();
+    let backing_file = backing.path().join("config.txt");
+    std::fs::write(&backing_file, "content from outside Blend\n").unwrap();
+    let target = home.path().join(".config/plaintext-single/config.txt");
+    create_symlink(&backing_file, &target);
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-target-to-source", "plaintext-single"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("target structure does not match Source"));
+    assert_eq!(std::fs::read_to_string(&source).unwrap(), source_before);
+    assert_eq!(
+        std::fs::read_to_string(&backing_file).unwrap(),
+        "content from outside Blend\n"
+    );
+    assert!(target.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_intended_symlink_uses_explicit_reconciliation_for_existing_mismatches() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+    let order_dir = orders_dir(blend_dir.path()).join("symlink-entry");
+    std::fs::create_dir_all(&order_dir).unwrap();
+    let source = order_dir.join("source.txt");
+    std::fs::write(&source, "source content\n").unwrap();
+    std::fs::write(
+        order_dir.join("order.ncl"),
+        r#"{
+  blend = {
+    prefix = ["~/.config/symlink-entry/"],
+    files = [{ name = "config.txt", from_file = "source.txt", symlink = true }],
+  },
+}
+"#,
+    )
+    .unwrap();
+
+    let target = home.path().join(".config/symlink-entry/config.txt");
+    let initial = run_blend(home.path(), blend_dir.path(), &["sync", "symlink-entry"]);
+    assert!(initial.status.success());
+    assert_eq!(
+        std::fs::read_link(&target).unwrap(),
+        source.canonicalize().unwrap()
+    );
+
+    std::fs::remove_file(&target).unwrap();
+    create_symlink(Path::new("wrong-target"), &target);
+    let skipped = run_blend_with_stdin(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "symlink-entry"],
+        "k\n",
+    );
+    assert!(skipped.status.success());
+    assert_eq!(
+        std::fs::read_link(&target).unwrap(),
+        PathBuf::from("wrong-target")
+    );
+
+    let pull = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-target-to-source", "symlink-entry"],
+    );
+    let pull_stdout = String::from_utf8_lossy(&pull.stdout);
+    assert!(pull.status.success());
+    assert!(pull_stdout.contains("target structure does not match Source"));
+    assert_eq!(
+        std::fs::read_link(&target).unwrap(),
+        PathBuf::from("wrong-target")
+    );
+
+    let pushed = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "symlink-entry"],
+    );
+    assert!(pushed.status.success());
+    assert_eq!(
+        std::fs::read_link(&target).unwrap(),
+        source.canonicalize().unwrap()
+    );
+
+    std::fs::remove_file(&target).unwrap();
+    std::fs::write(&target, "regular target\n").unwrap();
+    let view = run_blend(home.path(), blend_dir.path(), &["view", "symlink-entry"]);
+    let view_stdout = String::from_utf8_lossy(&view.stdout);
+    assert!(view_stdout.contains("type mismatch: expected symlink, found file"));
+    assert_eq!(
+        std::fs::read_to_string(&target).unwrap(),
+        "regular target\n"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_directory_backed_symlink_does_not_inspect_children_through_wrong_link() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+    let order_dir = orders_dir(blend_dir.path()).join("symlink-directory");
+    let source = order_dir.join("source");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(source.join("managed.txt"), "managed content\n").unwrap();
+    std::fs::write(
+        order_dir.join("order.ncl"),
+        r#"{
+  blend = {
+    prefix = ["~/.config/symlink-directory/"],
+    files = [{ name = "config", from_file = "source", symlink = true }],
+  },
+}
+"#,
+    )
+    .unwrap();
+
+    let wrong_target = home.path().join("wrong-target.txt");
+    std::fs::write(&wrong_target, "not a directory\n").unwrap();
+    let target = home.path().join(".config/symlink-directory/config");
+    create_symlink(&wrong_target, &target);
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "symlink-directory"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "sync failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("errors"),
+        "unexpected sync error:\n{stdout}"
+    );
+    assert_eq!(
+        std::fs::read_link(&target).unwrap(),
+        source.canonicalize().unwrap()
+    );
+}
+
+#[test]
+fn test_status_compares_local_overlay_content_from_effective_inventory() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = TempDir::new().unwrap();
+    copy_shared_order_files(blend_dir.path());
+    let order_dir = orders_dir(blend_dir.path()).join("local-overlay-status");
+    let source = order_dir.join("source");
+    let local = order_dir.join("local");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::create_dir_all(&local).unwrap();
+    std::fs::write(source.join("tracked.txt"), "tracked content\n").unwrap();
+    std::fs::write(local.join("local.txt"), "local content\n").unwrap();
+    std::fs::write(
+        order_dir.join("order.ncl"),
+        r#"{
+  blend = {
+    prefix = ["~/.config/local-overlay-status/"],
+    files = [{ name = "config", from_file = "source", local = "local" }],
+  },
+}
+"#,
+    )
+    .unwrap();
+
+    let deploy = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "local-overlay-status"],
+    );
+    assert!(deploy.status.success());
+
+    let local_target = home
+        .path()
+        .join(".config/local-overlay-status/config/local.txt");
+    std::fs::write(&local_target, "drifted local content\n").unwrap();
+
+    let status = run_blend(home.path(), blend_dir.path(), &["status"]);
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    let stderr = String::from_utf8_lossy(&status.stderr);
+    assert!(
+        status.status.success(),
+        "status failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("deployed"));
+    assert!(
+        stdout.contains("\u{2260}"),
+        "local overlay drift must be reported:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_regular_file_and_directory_type_mismatches_share_reconciliation() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("plaintext-single");
+    let file_target = home.path().join(".config/plaintext-single/config.txt");
+    std::fs::create_dir_all(&file_target).unwrap();
+    std::fs::write(
+        file_target.join("unmanaged.txt"),
+        "keep until explicit push",
+    )
+    .unwrap();
+
+    let view = run_blend(home.path(), blend_dir.path(), &["view", "plaintext-single"]);
+    assert!(
+        String::from_utf8_lossy(&view.stdout)
+            .contains("type mismatch: expected file, found directory")
+    );
+
+    let skipped = run_blend_with_stdin(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "plaintext-single"],
+        "k\n",
+    );
+    assert!(skipped.status.success());
+    assert!(file_target.is_dir());
+
+    let pushed = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "plaintext-single"],
+    );
+    assert!(pushed.status.success());
+    assert!(file_target.is_file());
+
+    let dir_blend = copy_fixture("plaintext-dir");
+    let dir_target = home.path().join(".config/plaintext-dir/conf");
+    std::fs::create_dir_all(dir_target.parent().unwrap()).unwrap();
+    std::fs::write(&dir_target, "wrong node type\n").unwrap();
+    let dir_view = run_blend(home.path(), dir_blend.path(), &["view", "plaintext-dir"]);
+    assert!(
+        String::from_utf8_lossy(&dir_view.stdout)
+            .contains("type mismatch: expected directory, found file")
+    );
+    let dir_push = run_blend(
+        home.path(),
+        dir_blend.path(),
+        &["sync", "--force-source-to-target", "plaintext-dir"],
+    );
+    assert!(dir_push.status.success());
+    assert!(dir_target.is_dir());
+    assert!(dir_target.join("file1.txt").is_file());
+}
+
+/// A directory entry owns its managed children, so each child uses the same
+/// generic node-type comparison as a top-level target.
 #[test]
 #[cfg(unix)]
 fn test_status_shows_symlinked_for_inner_file_symlink() {
@@ -1940,8 +2243,8 @@ fn test_status_shows_symlinked_for_inner_file_symlink() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success());
     assert!(
-        stdout.contains("symlinked"),
-        "Status must show 'symlinked' when an inner file in a directory entry is a symlink:\n{stdout}"
+        stdout.contains("mismatch"),
+        "Status must show a mismatch for an inner file symlink:\n{stdout}"
     );
 }
 
@@ -1963,8 +2266,8 @@ fn test_view_annotates_inner_file_symlink() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success());
     assert!(
-        stdout.contains("unexpected symlink"),
-        "View must annotate inner-file symlink:\n{stdout}"
+        stdout.contains("type mismatch: expected file, found symlink"),
+        "View must annotate the inner-file type mismatch:\n{stdout}"
     );
     assert!(
         stdout.contains("file1.txt"),
@@ -1974,9 +2277,7 @@ fn test_view_annotates_inner_file_symlink() {
 
 #[test]
 #[cfg(unix)]
-fn test_sync_interactive_auto_replaces_inner_file_symlink() {
-    // Pure-symlink-no-content-diff case for an inner file. Interactive sync
-    // should auto-redeploy (no prompt), matching the top-level symlink UX.
+fn test_sync_interactive_does_not_replace_inner_file_symlink_automatically() {
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
     run_blend(
@@ -1988,13 +2289,11 @@ fn test_sync_interactive_auto_replaces_inner_file_symlink() {
     let inner = home.path().join(".config/plaintext-dir/conf/file1.txt");
     let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&inner);
 
-    // Interactive sync (no --force-source-to-target) — must NOT prompt because there's no
-    // content diff, only a structural symlink mismatch.
-    let output = run_blend(home.path(), &orders, &["sync", "plaintext-dir"]);
+    let output = run_blend_with_stdin(home.path(), &orders, &["sync", "plaintext-dir"], "k\n");
     assert!(output.status.success());
     assert!(
-        !inner.symlink_metadata().unwrap().file_type().is_symlink(),
-        "Inner-file symlink must be auto-replaced in interactive mode when content matches"
+        inner.symlink_metadata().unwrap().file_type().is_symlink(),
+        "Inner-file symlink must remain after skipping the type mismatch"
     );
 }
 
@@ -2029,12 +2328,105 @@ fn test_sync_force_source_to_target_replaces_inner_file_symlink() {
 
 #[test]
 #[cfg(unix)]
-fn test_view_annotates_symlink_when_content_also_differs() {
-    // Real-world ncdu shape: parent directory of the target is a symlink
-    // to a backing tree, AND the resolved file content differs from
-    // the source. View must show BOTH the diff and the symlink annotation,
-    // not just the diff (otherwise the user can't tell that a redeploy
-    // is needed to restructure the path).
+fn test_force_target_to_source_does_not_follow_inner_file_symlink() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("plaintext-dir");
+    run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "plaintext-dir"],
+    );
+
+    let source = orders_dir(blend_dir.path()).join("plaintext-dir/conf/file1.txt");
+    let source_before = std::fs::read_to_string(&source).unwrap();
+    let inner = home.path().join(".config/plaintext-dir/conf/file1.txt");
+    let backing = TempDir::new().unwrap();
+    let backing_file = backing.path().join("file1.txt");
+    std::fs::write(&backing_file, "external content\n").unwrap();
+    std::fs::remove_file(&inner).unwrap();
+    create_symlink(&backing_file, &inner);
+
+    let output = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-target-to-source", "plaintext-dir"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("target structure does not match Source"));
+    assert_eq!(std::fs::read_to_string(&source).unwrap(), source_before);
+    assert_eq!(
+        std::fs::read_to_string(&backing_file).unwrap(),
+        "external content\n"
+    );
+    assert!(inner.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_managed_child_directory_symlink_uses_generic_type_reconciliation() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("plaintext-dir");
+    let source_nested = orders_dir(blend_dir.path()).join("plaintext-dir/conf/nested/config.txt");
+    std::fs::create_dir_all(source_nested.parent().unwrap()).unwrap();
+    std::fs::write(&source_nested, "managed nested content\n").unwrap();
+    run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "plaintext-dir"],
+    );
+
+    let target_nested = home.path().join(".config/plaintext-dir/conf/nested");
+    std::fs::remove_dir_all(&target_nested).unwrap();
+    let backing = TempDir::new().unwrap();
+    std::fs::write(
+        backing.path().join("config.txt"),
+        "managed nested content\n",
+    )
+    .unwrap();
+    create_symlink(backing.path(), &target_nested);
+
+    let view = run_blend(home.path(), blend_dir.path(), &["view", "plaintext-dir"]);
+    let view_stdout = String::from_utf8_lossy(&view.stdout);
+    assert!(view_stdout.contains("type mismatch: expected directory, found symlink"));
+
+    let skipped = run_blend_with_stdin(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "plaintext-dir"],
+        "k\n",
+    );
+    assert!(skipped.status.success());
+    assert!(
+        target_nested
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+
+    let pushed = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "plaintext-dir"],
+    );
+    assert!(pushed.status.success());
+    assert!(target_nested.symlink_metadata().unwrap().is_dir());
+    assert_eq!(
+        std::fs::read_to_string(target_nested.join("config.txt")).unwrap(),
+        "managed nested content\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(backing.path().join("config.txt")).unwrap(),
+        "managed nested content\n"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_view_ignores_parent_symlink_and_compares_target_content() {
+    // Parent components are path-resolution infrastructure. The managed leaf
+    // is a regular file, so view should report only its content difference.
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();
 
@@ -2064,14 +2456,25 @@ fn test_view_annotates_symlink_when_content_also_differs() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success());
     assert!(
-        stdout.contains("symlinked, needs re-deploy"),
-        "view must annotate symlink even when content also differs:\n{stdout}"
+        !stdout.contains("type mismatch"),
+        "view must not report the parent symlink as a target mismatch:\n{stdout}"
     );
     // And the content diff must still be shown
     assert!(
         stdout.contains("old backing content"),
         "view must still show the content diff:\n{stdout}"
     );
+
+    let sync = run_blend(
+        home.path(),
+        &orders,
+        &["sync", "--force-source-to-target", "plaintext-single"],
+    );
+    assert!(sync.status.success());
+    assert!(parent.symlink_metadata().unwrap().file_type().is_symlink());
+    let source_content =
+        std::fs::read_to_string(fixtures_dir().join("orders/plaintext-single/config.txt")).unwrap();
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), source_content);
 }
 
 #[test]
@@ -2090,14 +2493,14 @@ fn test_status_shows_symlink_mismatch() {
     let target = home.path().join(".config/plaintext-single/config.txt");
     let (_backing_dir, _backing_file, _) = replace_with_unexpected_symlink(&target);
 
-    // Status should show "symlinked" status
+    // Status should show a generic node-type mismatch.
     let output = run_blend(home.path(), &orders, &[]);
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
     assert!(
-        stdout.contains("symlinked"),
-        "Status should show 'symlinked' for unexpected symlink target:\n{stdout}"
+        stdout.contains("mismatch"),
+        "Status should show a mismatch for the symlink target:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary

- classify managed filesystem nodes without following the final symlink
- treat existing type and symlink-destination mismatches as explicit sync conflicts
- preserve symlinked parent paths and replace only exact managed nodes on Source-to-Target resolution
- compare directory entries from the same merged, excluded deployment inventory used for writes
- propagate target inspection and managed-inventory failures instead of treating them as missing or unchanged

## Behavior

- broken symlinks are existing type mismatches, not missing targets
- Target-to-Source is unavailable for structural mismatches and never reads symlink referents
- interactive sync no longer silently replaces matching-content symlinks
- intended symlink entries use the same explicit reconciliation flow for existing mismatches
- directory-backed symlink entries compare only the exact target link, without inspecting children
- regular-file, directory, and managed-child type mismatches share one model
- directory status compares content from the effective merged, local-overlay, and excluded inventory
- operational inspection failures surface as errors and do not trigger reconciliation or snapshot updates

## Validation

- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --release (252 unit tests, 79 end-to-end tests)
- cargo run -- check
- cargo run -- format --check

## Summary by Sourcery

Unify target node reconciliation across status, view, diff, and sync while making structural mismatches explicit and filesystem inspection failures actionable.

Bug Fixes:
- Reconcile filesystem targets by exact node type, correctly handling broken symlinks, type mismatches, and symlink destinations without following final symlinks.
- Prevent Target-to-Source synchronization from reading or overwriting symlink referents when structural mismatches exist.
- Preserve symlinked parent paths while replacing only the managed target node during Source-to-Target synchronization.
- Ensure directory comparisons use the effective merged inventory, including local overlays and exclusions.

Enhancements:
- Surface filesystem inspection, inventory construction, and content comparison failures as explicit errors instead of treating targets as missing or unchanged.
- Unify status, view, diff, and sync reporting around generic file, directory, and symlink node reconciliation.

Tests:
- Add unit and end-to-end coverage for broken symlinks, node-type mismatches, symlink preservation, managed directory inventories, local overlays, exclusions, and operational failures.