### PR TITLE
fix(blend): preserve comments during field deletion

### DIFF
--- a/blend/src/nickel/ast_utils.rs
+++ b/blend/src/nickel/ast_utils.rs
@@ -915,42 +915,15 @@ pub fn surgical_rewrite_with_structure(
                     push_unique(&mut unapplied, path);
                     continue;
                 };
+                let FieldDeletionSpan::Safe(delete_range) =
+                    field_deletion_span(source, &structure.comments, field.full_range.clone())
+                else {
+                    push_unique(&mut unapplied, path);
+                    continue;
+                };
+
                 push_unique(&mut applied, path);
-
-                // Determine what byte range to delete.
-                // We want to remove the entire field definition, including the
-                // preceding newline and indentation.
-                let bytes = source.as_bytes();
-
-                // Find the start of the line containing this field
-                // Start deletion AFTER the preceding newline (keep it for the previous line)
-                let line_start = source[..field.full_range.start]
-                    .rfind('\n')
-                    .map(|pos| pos + 1) // skip the \n itself
-                    .unwrap_or(field.full_range.start);
-
-                let delete_start = leading_comment_block_start(
-                    source,
-                    &structure.comments,
-                    line_start,
-                    field.full_range.start,
-                );
-                let mut delete_end = field.full_range.end;
-
-                // Also consume trailing whitespace and newline after the field
-                while delete_end < source.len()
-                    && (bytes[delete_end] == b' '
-                        || bytes[delete_end] == b'\t'
-                        || bytes[delete_end] == b'\n')
-                {
-                    if bytes[delete_end] == b'\n' {
-                        delete_end += 1;
-                        break;
-                    }
-                    delete_end += 1;
-                }
-
-                ops.push((delete_start, delete_end - delete_start, String::new()));
+                ops.push((delete_range.start, delete_range.len(), String::new()));
             }
         }
     }
@@ -973,16 +946,34 @@ pub fn surgical_rewrite_with_structure(
     })
 }
 
-/// Include a contiguous block of standalone comments immediately above a
-/// deleted field. Blank lines and inline comments form a boundary so comments
-/// belonging to the surrounding record or previous field are preserved.
-fn leading_comment_block_start(
+enum FieldDeletionSpan {
+    Safe(std::ops::Range<usize>),
+    Ambiguous,
+}
+
+/// Find the complete, safely-owned source range for a field deletion.
+///
+/// Contiguous standalone comments with the field's indentation are treated as
+/// leading documentation. A blank line or an inline comment after a previous
+/// field is an ownership boundary. A standalone adjacent comment with a
+/// different indentation is ambiguous, so the field is left untouched.
+fn field_deletion_span(
     source: &str,
     comments: &[std::ops::Range<usize>],
-    field_line_start: usize,
-    field_start: usize,
-) -> usize {
-    let field_indent = &source[field_line_start..field_start];
+    field_range: std::ops::Range<usize>,
+) -> FieldDeletionSpan {
+    let field_line_start = source[..field_range.start]
+        .rfind('\n')
+        .map(|pos| pos + 1)
+        .unwrap_or(0);
+    let field_indent = &source[field_line_start..field_range.start];
+    if !field_indent
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        return FieldDeletionSpan::Ambiguous;
+    }
+
     let mut delete_start = field_line_start;
 
     while let Some(comment) = comments
@@ -1001,14 +992,49 @@ fn leading_comment_block_start(
             .rfind('\n')
             .map(|pos| pos + 1)
             .unwrap_or(0);
-        if &source[comment_line_start..comment.start] != field_indent {
+        let comment_prefix = &source[comment_line_start..comment.start];
+        if !comment_prefix
+            .bytes()
+            .all(|byte| matches!(byte, b' ' | b'\t'))
+        {
+            // This is an inline comment belonging to the previous field.
             break;
+        }
+        if comment_prefix != field_indent {
+            return FieldDeletionSpan::Ambiguous;
         }
 
         delete_start = comment_line_start;
     }
 
-    delete_start
+    let mut delete_end = field_range.end;
+    let line_end = source[delete_end..]
+        .find('\n')
+        .map(|offset| delete_end + offset)
+        .unwrap_or(source.len());
+    let trailing_comment = comments
+        .iter()
+        .filter(|comment| comment.start >= delete_end && comment.start <= line_end)
+        .min_by_key(|comment| comment.start)
+        .filter(|comment| {
+            source[delete_end..comment.start]
+                .bytes()
+                .all(|byte| matches!(byte, b' ' | b'\t' | b'\r'))
+        });
+
+    if let Some(comment) = trailing_comment {
+        delete_end = comment.end;
+    }
+
+    let bytes = source.as_bytes();
+    while delete_end < source.len() && matches!(bytes[delete_end], b' ' | b'\t' | b'\r') {
+        delete_end += 1;
+    }
+    if delete_end < source.len() && bytes[delete_end] == b'\n' {
+        delete_end += 1;
+    }
+
+    FieldDeletionSpan::Safe(delete_start..delete_end)
 }
 
 /// Determine the indentation level of a from_config block by looking at the source.

--- a/blend/src/nickel/structure_map.rs
+++ b/blend/src/nickel/structure_map.rs
@@ -933,7 +933,7 @@ mod tests {
         name = "test.toml",
         from_config = {
           # Record-level note
-
+          \t
           # Field-specific note
           a = 1,
           b = 2,
@@ -941,17 +941,177 @@ mod tests {
       },
     ],
   },
-}"#;
+}"#
+        .replace("\\t", "\t");
 
-        let structure = build_structure_map(source, 0).unwrap();
+        let structure = build_structure_map(&source, 0).unwrap();
         let edits = vec![FieldEdit::Delete { path: kp("a") }];
-        let result = surgical_rewrite_with_structure(source, &structure, &[], &edits, 5)
+        let result = surgical_rewrite_with_structure(&source, &structure, &[], &edits, 5)
             .unwrap()
             .new_source;
 
         assert!(result.contains("Record-level note"));
         assert!(!result.contains("Field-specific note"));
         assert!(result.contains("b = 2"));
+    }
+
+    #[test]
+    fn delete_nested_field_removes_contiguous_leading_doc_comments() {
+        use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
+
+        let source = r#"{
+  blend = {
+    files = [
+      {
+        name = "test.toml",
+        from_config = {
+          section = {
+            keep = 1,
+            # First line describing remove
+            # Second line describing remove
+            remove = 2,
+            # Documentation for after
+            after = 3,
+          },
+        },
+      },
+    ],
+  },
+}"#;
+
+        let structure = build_structure_map(source, 0).unwrap();
+        let edits = vec![FieldEdit::Delete {
+            path: kp("section.remove"),
+        }];
+        let result = surgical_rewrite_with_structure(source, &structure, &[], &edits, 5)
+            .unwrap()
+            .new_source;
+
+        assert!(result.contains("keep = 1"));
+        assert!(!result.contains("describing remove"));
+        assert!(result.contains("# Documentation for after\n            after = 3"));
+        build_structure_map(&result, 0).unwrap();
+    }
+
+    #[test]
+    fn delete_field_removes_multiline_comments_with_trailing_horizontal_whitespace() {
+        use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
+
+        let source = r#"{
+  blend = {
+    files = [
+      {
+        name = "test.toml",
+        from_config = {
+          keep = 1,
+          # First documentation line<spaces>
+          # Second documentation line\t
+          remove = 2,
+          after = 3,
+        },
+      },
+    ],
+  },
+}"#
+        .replace("<spaces>", "   ")
+        .replace("\\t", "\t");
+
+        let structure = build_structure_map(&source, 0).unwrap();
+        let edits = vec![FieldEdit::Delete { path: kp("remove") }];
+        let result = surgical_rewrite_with_structure(&source, &structure, &[], &edits, 5)
+            .unwrap()
+            .new_source;
+
+        assert!(!result.contains("documentation line"));
+        assert!(result.contains("keep = 1,\n          after = 3"));
+    }
+
+    #[test]
+    fn delete_field_preserves_comment_for_following_field() {
+        use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
+
+        let source = r#"{
+  blend = {
+    files = [
+      {
+        name = "test.toml",
+        from_config = {
+          remove = 1,
+          # Documentation for keep
+          keep = 2,
+        },
+      },
+    ],
+  },
+}"#;
+
+        let structure = build_structure_map(source, 0).unwrap();
+        let edits = vec![FieldEdit::Delete { path: kp("remove") }];
+        let result = surgical_rewrite_with_structure(source, &structure, &[], &edits, 5)
+            .unwrap()
+            .new_source;
+
+        assert!(!result.contains("remove = 1"));
+        assert!(result.contains("# Documentation for keep\n          keep = 2"));
+    }
+
+    #[test]
+    fn delete_field_removes_trailing_same_line_comment() {
+        use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
+
+        let source = r#"{
+  blend = {
+    files = [
+      {
+        name = "test.toml",
+        from_config = {
+          remove = 1, # Documentation for remove
+          keep = 2,
+        },
+      },
+    ],
+  },
+}"#;
+
+        let structure = build_structure_map(source, 0).unwrap();
+        let edits = vec![FieldEdit::Delete { path: kp("remove") }];
+        let result = surgical_rewrite_with_structure(source, &structure, &[], &edits, 5)
+            .unwrap()
+            .new_source;
+
+        assert!(!result.contains("remove = 1"));
+        assert!(!result.contains("Documentation for remove"));
+        assert!(result.contains("from_config = {\n          keep = 2"));
+        build_structure_map(&result, 0).unwrap();
+    }
+
+    #[test]
+    fn delete_field_with_mismatched_comment_indentation_is_unapplied() {
+        use super::super::ast_utils::{FieldEdit, surgical_rewrite_with_structure};
+
+        let source = r#"{
+  blend = {
+    files = [
+      {
+        name = "test.toml",
+        from_config = {
+        # Ambiguous record-level documentation
+          remove = 1,
+          keep = 2,
+        },
+      },
+    ],
+  },
+}"#;
+
+        let structure = build_structure_map(source, 0).unwrap();
+        let path = kp("remove");
+        let edits = vec![FieldEdit::Delete { path: path.clone() }];
+        let outcome = surgical_rewrite_with_structure(source, &structure, &[], &edits, 5).unwrap();
+
+        assert_eq!(outcome.new_source, source);
+        assert!(outcome.applied.is_empty());
+        assert_eq!(outcome.unapplied, vec![path]);
     }
 
     // -----------------------------------------------------------------------

--- a/blend/tests/sync_e2e.rs
+++ b/blend/tests/sync_e2e.rs
@@ -619,6 +619,66 @@ fn test_sync_force_source_to_target_then_no_changes() {
 }
 
 #[test]
+fn test_sync_target_to_source_deletion_removes_field_comments() {
+    let home = TempDir::new().unwrap();
+    let blend_dir = copy_fixture("toml-basic");
+    let order_path = orders_dir(blend_dir.path()).join("toml-basic/order.ncl");
+    let source = std::fs::read_to_string(&order_path).unwrap().replace(
+        "          number = 42,",
+        "          # Numeric setting\n          number = 42, # Stored as a number",
+    );
+    std::fs::write(&order_path, source).unwrap();
+
+    let deploy = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-source-to-target", "toml-basic"],
+    );
+    assert!(
+        deploy.status.success(),
+        "initial deployment failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&deploy.stdout),
+        String::from_utf8_lossy(&deploy.stderr)
+    );
+
+    let target = home.path().join(".config/toml-basic/config.toml");
+    let deployed = std::fs::read_to_string(&target).unwrap();
+    let without_number = deployed
+        .lines()
+        .filter(|line| !line.starts_with("number"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&target, format!("{without_number}\n")).unwrap();
+
+    let pull = run_blend(
+        home.path(),
+        blend_dir.path(),
+        &["sync", "--force-target-to-source", "toml-basic"],
+    );
+    assert!(
+        pull.status.success(),
+        "target-to-source deletion failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&pull.stdout),
+        String::from_utf8_lossy(&pull.stderr)
+    );
+
+    let rewritten = std::fs::read_to_string(&order_path).unwrap();
+    assert!(!rewritten.contains("number = 42"));
+    assert!(!rewritten.contains("Numeric setting"));
+    assert!(!rewritten.contains("Stored as a number"));
+    assert!(rewritten.contains("key = \"value\""));
+    assert!(rewritten.contains("nested = {"));
+
+    let check = run_blend(home.path(), blend_dir.path(), &["check", "toml-basic"]);
+    assert!(
+        check.status.success(),
+        "rewritten order should remain valid:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+}
+
+#[test]
 fn test_sync_dry_run_no_changes() {
     let home = TempDir::new().unwrap();
     let orders = fixtures_dir();


### PR DESCRIPTION
## Summary

- remove field-owned leading and same-line comments during Nickel field deletion
- preserve comments for surrounding records and following fields
- leave ambiguous comment layouts unresolved instead of rewriting source unsafely
- cover nested, whitespace, trailing-comment, and end-to-end Target-to-Source deletion cases

## Validation

- just fmt-check
- just clippy
- just test
- cargo run --release -- check
- cargo run --release -- format --check

## Summary by Sourcery

Preserve comment ownership and source validity during Nickel field deletion.

Bug Fixes:
- Preserve surrounding and following-field comments when deleting Nickel fields while removing comments owned by the deleted field.
- Avoid applying field deletions when comment ownership is ambiguous, preventing unsafe source rewrites.

Enhancements:
- Handle nested fields, whitespace, trailing same-line comments, and comment ownership boundaries during surgical source edits.

Tests:
- Add unit coverage for nested field deletion, comment preservation and removal, whitespace handling, and ambiguous indentation.
- Add an end-to-end test covering target-to-source deletion of a field with leading and trailing comments.